### PR TITLE
[FIX] Resolves dataframe formatting issue

### DIFF
--- a/abagen/io.py
+++ b/abagen/io.py
@@ -50,11 +50,6 @@ def _make_parquet(fname, convert_only=False):
         if convert_only:
             return
 
-    # do some cleaning up of the data
-    data = data.set_index('0')
-    data.index.name = 'probe_id'
-    data.columns = pd.Series(range(len(data.columns)), name='sample_id')
-
     return data
 
 
@@ -86,9 +81,14 @@ def read_microarray(fname, parquet=True):
                             .format(fname))
 
     if use_parq and parquet:
-        return _make_parquet(fname, convert_only=False)
+        data = _make_parquet(fname, convert_only=False).set_index('0')
+    else:
+        data = pd.read_csv(fname, header=None, index_col=0)
 
-    return pd.read_csv(fname, header=None, index_col=0)
+    data.index.name = 'probe_id'
+    data.columns = pd.Series(range(len(data.columns)), name='sample_id')
+
+    return data
 
 
 def read_ontology(fname, parquet=True):
@@ -146,9 +146,14 @@ def read_pacall(fname, parquet=True):
                             .format(fname))
 
     if use_parq and parquet:
-        return _make_parquet(fname, convert_only=False)
+        data = _make_parquet(fname, convert_only=False).set_index('0')
+    else:
+        data = pd.read_csv(fname, header=None, index_col=0)
 
-    return pd.read_csv(fname, header=None, index_col=0)
+    data.index.name = 'probe_id'
+    data.columns = pd.Series(range(len(data.columns)), name='sample_id')
+
+    return data
 
 
 def read_probes(fname, parquet=True):


### PR DESCRIPTION
Loading data using the `abagen.io` functions that rely on parquet cause some downstream errors when parquet isn't installed. That is, the columns and index name of `microarray` and `pacall` dataframes weren't being set correctly if the parquet version of these files didn't exist, resulting in indexing errors during a call to `get_expression_data()`.

Since parquet is _supposed_ to be optional, this is obviously undesired. This commit ensures that columns / index names are set correctly regardless of whether they are loaded with `parquet` or `pandas`.