### PR TITLE
[REF] Updates get_expression_data()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,11 @@ taken from [1]_ and is separately licensed under the `CC BY 4.0 <https://
 creativecommons.org/licenses/by/4.0/legalcode>`_; these data can also be found
 on `figshare <https://figshare.com/s/441295fe494375aa0c13>`_.
 
+Corrected MNI coordinates used to match AHBA tissues samples to MNI space
+located at `abagen/data/corrected_mni_coordinates.csv` are taken from the
+`alleninf package <https://github.com/chrisfilo/alleninf>`, provided under the
+3-clause BSD license.
+
 All trademarks referenced herein are property of their respective holders.
 
 .. |sparkles| replace:: ✨

--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -384,7 +384,7 @@ def get_expression_data(atlas, atlas_info=None, *, exact=True,
     num_subj = len(files.microarray)
     all_labels = utils.get_unique_labels(atlas)
     if not exact:
-        centroids = utils.get_centroids(atlas, labels_of_interest=all_labels)
+        centroids = utils.get_centroids(atlas, labels=all_labels)
 
     # reannotate probes based on updates from Arnatkeviciute et al., 2018 then
     # perform intensity-based filter of probes and select probe with highest

--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -3,13 +3,15 @@
 Functions for mapping AHBA microarray dataset to atlases and and parcellations
 in MNI space
 """
+
 from functools import reduce
+
 from nilearn._utils import check_niimg_3d
 import numpy as np
 import pandas as pd
 from scipy.spatial.distance import cdist
-from sklearn.utils import Bunch
-from abagen import io, process, utils
+
+from abagen import datasets, io, process, utils
 
 
 def _assign_sample(sample, atlas, sample_info=None, atlas_info=None,
@@ -237,12 +239,12 @@ def group_by_label(microarray, sample_labels, labels=None, metric='mean'):
     return gene_by_label
 
 
-def get_expression_data(files, atlas, atlas_info=None, *, exact=True,
+def get_expression_data(atlas, atlas_info=None, *, donors='all', exact=True,
                         tolerance=2, metric='mean', ibf_threshold=0.5,
                         corrected_mni=True, reannotated=True,
                         return_counts=False, return_donors=False):
     """
-    Assigns microarray expression data in `files` to ROIs defined in `atlas`
+    Assigns microarray expression data to ROIs defined in `atlas`
 
     This function aims to provide a workflow for generating pre-processed,
     microarray expression data for abitrary `atlas` designations. First, some
@@ -286,11 +288,6 @@ def get_expression_data(files, atlas, atlas_info=None, *, exact=True,
 
     Parameters
     ----------
-    files : dict
-        Optimally obtained by calling `abagen.fetch_microarray()`, this should
-        be a dict with keys ['annotation', 'microarray', 'ontology', 'pacall',
-        'probes'], where corresponding values are lists of filepaths to
-        downloaded AHBA data
     atlas : niimg-like object
         A parcellation image in MNI space, where each parcel is identified by a
         unique integer ID
@@ -300,6 +297,10 @@ def get_expression_data(files, atlas, atlas_info=None, *, exact=True,
         containing information mapping atlas IDs to hemisphere (i.e, "L", "R")
         and broad structural class (i.e., "cortex", "subcortex", "cerebellum").
         Default: None
+    donors : list, optional
+        List of donors to use as sources of expression data. Can be either
+        donor numbers or UID. If not specified will use all available donors.
+        Default: 'all'
     exact : bool, optional
         Whether to use exact matching of donor tissue samples to parcels in
         `atlas`. If True, this function will match tissue samples to parcels
@@ -343,12 +344,13 @@ def get_expression_data(files, atlas, atlas_info=None, *, exact=True,
 
     Returns
     -------
-    expression : (R x G) :class:`pandas.DataFrame`
+    expression : (R, G) :class:`pandas.DataFrame`
         Microarray expression for `R` regions in `atlas` for `G` genes,
-        aggregated across donors.
-    counts : (R x D) :class:`pandas.DataFrame`
+        aggregated across donors, where the index corresponds to the unique
+        integer IDs of `atlas` and the columns are gene names.
+    counts : (R, D) :class:`pandas.DataFrame`
         Number of samples assigned to each of `R` regions in `atlas` for each
-        of `D` donors (if multiple donors provided); only returned if
+        of `D` donors (if multiple donors were specified); only returned if
         `return_counts=True`.
 
     References
@@ -358,8 +360,8 @@ def get_expression_data(files, atlas, atlas_info=None, *, exact=True,
        data. bioRxiv, 380089.
     """
 
-    # coerce to Bunch in case a simple dictionary was provided
-    files = Bunch(**files)
+    # fetch files
+    files = datasets.fetch_microarray(donors=donors)
     for key in ['microarray', 'probes', 'annotation', 'pacall', 'ontology']:
         if key not in files:
             raise KeyError('Provided `files` dictionary is missing {}. '
@@ -391,8 +393,7 @@ def get_expression_data(files, atlas, atlas_info=None, *, exact=True,
     probes = process.get_stable_probes(files.microarray, files.annotation,
                                        probes)
 
-    expression = []
-    missing = []
+    expression, missing = [], []
     counts = pd.DataFrame(np.zeros((len(all_labels) + 1, num_subj)),
                           index=np.append([0], all_labels))
     for subj in range(num_subj):

--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -239,10 +239,11 @@ def group_by_label(microarray, sample_labels, labels=None, metric='mean'):
     return gene_by_label
 
 
-def get_expression_data(atlas, atlas_info=None, *, donors='all', exact=True,
+def get_expression_data(atlas, atlas_info=None, *, exact=True,
                         tolerance=2, metric='mean', ibf_threshold=0.5,
                         corrected_mni=True, reannotated=True,
-                        return_counts=False, return_donors=False):
+                        return_counts=False, return_donors=False,
+                        donors='all', data_dir=None):
     """
     Assigns microarray expression data to ROIs defined in `atlas`
 
@@ -297,10 +298,6 @@ def get_expression_data(atlas, atlas_info=None, *, donors='all', exact=True,
         containing information mapping atlas IDs to hemisphere (i.e, "L", "R")
         and broad structural class (i.e., "cortex", "subcortex", "cerebellum").
         Default: None
-    donors : list, optional
-        List of donors to use as sources of expression data. Can be either
-        donor numbers or UID. If not specified will use all available donors.
-        Default: 'all'
     exact : bool, optional
         Whether to use exact matching of donor tissue samples to parcels in
         `atlas`. If True, this function will match tissue samples to parcels
@@ -341,6 +338,14 @@ def get_expression_data(atlas, atlas_info=None, *, donors='all', exact=True,
     return_donors : bool, optional
         Whether to return donor-level expression arrays instead of aggregating
         expression across donors with provided `metric`. Default: False
+    donors : list, optional
+        List of donors to use as sources of expression data. Can be either
+        donor numbers or UID. If not specified will use all available donors.
+        Default: 'all'
+    data_dir : str, optional
+        Directory where expression data should be downloaded (if it does not
+        already exist) / loaded. If not specified will use the current
+        directory. Default: None
 
     Returns
     -------
@@ -361,7 +366,7 @@ def get_expression_data(atlas, atlas_info=None, *, donors='all', exact=True,
     """
 
     # fetch files
-    files = datasets.fetch_microarray(donors=donors)
+    files = datasets.fetch_microarray(data_dir=data_dir, donors=donors)
     for key in ['microarray', 'probes', 'annotation', 'pacall', 'ontology']:
         if key not in files:
             raise KeyError('Provided `files` dictionary is missing {}. '

--- a/abagen/correct.py
+++ b/abagen/correct.py
@@ -50,8 +50,7 @@ def remove_distance(coexpression, atlas, atlas_info=None, labels=None):
     # load atlas_info, if provided
     atlas = check_niimg_3d(atlas)
     if atlas_info is not None:
-        atlas_info = utils.check_atlas_info(atlas, atlas_info,
-                                            labels_of_interest=labels)
+        atlas_info = utils.check_atlas_info(atlas, atlas_info, labels=labels)
         if labels is not None and len(labels) != len(coexpression):
             raise ValueError('Provided labels {} are a different length than '
                              'provided coexpression matrix of size {}. Please '
@@ -63,7 +62,7 @@ def remove_distance(coexpression, atlas, atlas_info=None, labels=None):
 
     # we'll do basic Euclidean distance correction for now
     # TODO: implement gray matter volume / cortical surface path distance
-    centroids = utils.get_centroids(atlas, labels_of_interest=labels)
+    centroids = utils.get_centroids(atlas, labels=labels)
     dist = cdist(centroids, centroids, metric='euclidean')
 
     corr_resid = np.zeros_like(coexpression)

--- a/abagen/tests/conftest.py
+++ b/abagen/tests/conftest.py
@@ -5,12 +5,12 @@ from abagen.datasets import fetch_microarray
 @pytest.fixture(scope='session')
 def testdir(tmpdir_factory):
     data_dir = tmpdir_factory.mktemp('data')
-    return data_dir
+    return str(data_dir)
 
 
 @pytest.fixture(scope='session')
 def testfiles(testdir):
-    files = fetch_microarray(data_dir=str(testdir),
+    files = fetch_microarray(data_dir=testdir,
                              donors=['12876', '15496'],
                              convert=True)
     return files

--- a/abagen/tests/test_allen.py
+++ b/abagen/tests/test_allen.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from nilearn._utils import check_niimg
 from nilearn.image import new_img_like
-import pytest
 from abagen import allen
 from abagen.datasets import fetch_desikan_killiany
 

--- a/abagen/tests/test_allen.py
+++ b/abagen/tests/test_allen.py
@@ -22,9 +22,6 @@ def test_vanilla_get_expression_data(testdir, testfiles):
     assert out.index.name == 'label'
     assert out.columns.name == 'gene_symbol'
 
-    with pytest.raises(KeyError):
-        allen.get_expression_data({'microarray': [1, 2, 3]}, ATLAS.image)
-
 
 def test_extra_get_expression_data(testdir, testfiles):
     for opts in [{'atlas_info': ATLAS.info},

--- a/abagen/tests/test_allen.py
+++ b/abagen/tests/test_allen.py
@@ -15,8 +15,9 @@ def test_label_samples(testfiles):
     assert out.columns == ['label']
 
 
-def test_vanilla_get_expression_data(testfiles):
-    out = allen.get_expression_data(testfiles, ATLAS.image)
+def test_vanilla_get_expression_data(testdir, testfiles):
+    out = allen.get_expression_data(ATLAS.image, data_dir=testdir,
+                                    donors=['12876', '15496'])
     assert isinstance(out, pd.DataFrame)
     assert out.index.name == 'label'
     assert out.columns.name == 'gene_symbol'
@@ -25,18 +26,19 @@ def test_vanilla_get_expression_data(testfiles):
         allen.get_expression_data({'microarray': [1, 2, 3]}, ATLAS.image)
 
 
-def test_extra_get_expression_data(testfiles):
+def test_extra_get_expression_data(testdir, testfiles):
     for opts in [{'atlas_info': ATLAS.info},
                  {'exact': False},
                  {'reannotated': False},
                  {'atlas_info': ATLAS.info, 'exact': False}]:
-        out = allen.get_expression_data(testfiles, ATLAS.image, **opts)
+        out = allen.get_expression_data(ATLAS.image, data_dir=testdir,
+                                        donors=['12876', '15496'], **opts)
         assert isinstance(out, pd.DataFrame)
         assert out.index.name == 'label'
         assert out.columns.name == 'gene_symbol'
 
 
-def test_missing_labels(testfiles):
+def test_missing_labels(testdir, testfiles):
     # remove some labels from atlas image so numbers are non-sequential
     remove = [10, 20, 60]
     # subset atlas image
@@ -48,8 +50,10 @@ def test_missing_labels(testfiles):
     atlas_info = pd.read_csv(ATLAS.info)
     atlas_info = atlas_info[~atlas_info.id.isin(remove)]
     # test get expression
-    out, counts = allen.get_expression_data(testfiles, atlas, atlas_info,
-                                            exact=False, return_counts=True)
+    out, counts = allen.get_expression_data(atlas, atlas_info,
+                                            exact=False, return_counts=True,
+                                            data_dir=testdir,
+                                            donors=['12876', '15496'])
     assert isinstance(out, pd.DataFrame)
     assert out.index.name == 'label'
     assert out.columns.name == 'gene_symbol'

--- a/abagen/tests/test_correct.py
+++ b/abagen/tests/test_correct.py
@@ -9,9 +9,11 @@ ATLAS = fetch_desikan_killiany()
 
 
 @pytest.fixture(scope='module')
-def donor_expression(testfiles):
-    return allen.get_expression_data(testfiles, ATLAS.image, ATLAS.info,
-                                     exact=False, return_donors=True)
+def donor_expression(testdir, testfiles):
+    return allen.get_expression_data(ATLAS.image, ATLAS.info,
+                                     exact=False, return_donors=True,
+                                     data_dir=testdir,
+                                     donors=['12876', '15496'])
 
 
 def test_remove_distance(donor_expression):

--- a/abagen/utils.py
+++ b/abagen/utils.py
@@ -14,7 +14,7 @@ AGG_FUNCS = dict(
 )
 
 
-def check_atlas_info(atlas, atlas_info, labels_of_interest=None):
+def check_atlas_info(atlas, atlas_info, labels=None):
     """
     Checks whether provided `info` on `atlas` is sufficient for processing
 
@@ -29,7 +29,7 @@ def check_atlas_info(atlas, atlas_info, labels_of_interest=None):
         'structure' containing information mapping atlas IDs to hemisphere and
         broad structural class (i.e., "cortex", "subcortex", "cerebellum").
         Default: None
-    labels_of_interest : array_like, optional
+    labels : array_like, optional
         List of values containing labels to compare between `atlas` and
         `atlas_info`, if they don't all match. Default: None
 
@@ -57,10 +57,10 @@ def check_atlas_info(atlas, atlas_info, labels_of_interest=None):
     if 'id' in atlas_info.columns:
         atlas_info = atlas_info.set_index('id')
 
-    if labels_of_interest is None:
+    if labels is None:
         ids = get_unique_labels(atlas)
     else:
-        ids = labels_of_interest
+        ids = labels
 
     cols = ['hemisphere', 'structure']
     try:
@@ -157,13 +157,13 @@ def get_unique_labels(label_image):
 
 def get_centroids(image, labels=None, image_space=False):
     """
-    Finds centroids of ``labels_of_interest`` in ``label_image``
+    Finds centroids of ``labels`` in ``label_image``
 
     Parameters
     ----------
     label_image : niimg-like object
         3D image containing integer label at each point
-    labels_of_interest : array_like, optional
+    labels : array_like, optional
         List of values containing labels of which to find centroids. Default:
         all possible labels
     image_space : bool, optional

--- a/abagen/utils.py
+++ b/abagen/utils.py
@@ -4,7 +4,7 @@ import itertools
 from nilearn._utils import check_niimg_3d
 import numpy as np
 import pandas as pd
-from scipy.ndimage.measurements import center_of_mass
+from scipy.ndimage import center_of_mass
 from scipy.spatial.distance import cdist
 from scipy.stats import zscore
 
@@ -155,7 +155,7 @@ def get_unique_labels(label_image):
     return np.trim_zeros(np.unique(label_image.get_data())).astype(int)
 
 
-def get_centroids(label_image, labels_of_interest=None, image_space=False):
+def get_centroids(image, labels=None, image_space=False):
     """
     Finds centroids of ``labels_of_interest`` in ``label_image``
 
@@ -176,20 +176,19 @@ def get_centroids(label_image, labels_of_interest=None, image_space=False):
         Coordinates of centroids for ROIs in input data
     """
 
-    label_image = check_niimg_3d(label_image)
+    image = check_niimg_3d(image)
+    data = image.get_data()
 
     # if no labels of interest provided, get all possible labels
-    if labels_of_interest is None:
-        labels_of_interest = get_unique_labels(label_image)
+    if labels is None:
+        labels = np.trim_zeros(np.unique(data))
 
     # get centroids for all possible labels
-    image_data = label_image.get_data()
-    centroids = np.row_stack([center_of_mass(image_data == label) for
-                              label in labels_of_interest])
+    centroids = np.row_stack(center_of_mass(data, labels=data, index=labels))
 
     # return xyz if desired; otherwise, ijk
     if image_space:
-        return ijk_to_xyz(centroids, label_image.affine)
+        centroids = ijk_to_xyz(centroids, image.affine)
 
     return centroids
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,7 +17,8 @@ following command:
 
 .. note::
 
-    Downloading the entire dataset (about 4GB) can take a long time!
+    Downloading the entire dataset (about 4GB) can take a long time depending
+    on your internet connection speed!
 
 This command will download data from all six available donors into a folder
 called ``allenbrain`` in the current directory. If you have already downloaded
@@ -26,7 +27,7 @@ have been stored:
 
 .. code-block:: python
 
-    >>> files = abagen.fetch_microarray(data_dir='/path/to/local/download', donors='all')
+    >>> files = abagen.fetch_microarray(data_dir='/path/to/files', donors='all')
 
 The returned object ``files`` is a dictionary with filepaths to the five
 different file types in the AHBA dataset:
@@ -133,7 +134,7 @@ we can process the data. This is as simple as:
 
 .. code-block:: python
 
-    >>> expression = abagen.get_expression_data(files, atlas.image, atlas.info)
+    >>> expression = abagen.get_expression_data(atlas.image, atlas.info)
 
 .. note::
 
@@ -172,7 +173,7 @@ specify the following:
 
 .. code-block:: python
 
-    >>> expression = abagen.get_expression_data(files, atlas.image, atlas.info, exact=False)
+    >>> expression = abagen.get_expression_data(atlas.image, atlas.info, exact=False)
     >>> expression.head()
     gene_symbol    MRPL49    ZNHIT2     ...       A_32_P9207  A_32_P94122
     label                               ...


### PR DESCRIPTION
Closes #35.

Calling `abagen.get_expression_data()` no longer requires users to pass a `files` object obtained from `abagen.fetch_microarray_data()` -- it just calls it automatically!