### PR TITLE
[FIX] Catches AttributeError w/pandas fastparquet

### DIFF
--- a/abagen/io.py
+++ b/abagen/io.py
@@ -14,7 +14,8 @@ try:
     eng = pd.io.parquet.get_engine('fastparquet')
     assert 'SNAPPY' in eng.api.compression.compressions
     use_parq = True
-except (ImportError, AssertionError):
+# pandas version too low OR don't have fastparquet installed
+except (AttributeError, ImportError, AssertionError):
     use_parq = False
 
 


### PR DESCRIPTION
If the installed version of pandas is too old then trying to call `pd.io.parquet.get_engine('fastparquet')` fails with an AttributeError because `pandas.io` does not have a parquet module. Since all the parquet nonsense is optional (and only really a small improvement in terms of load-time...), it doesn't make sense to pin the new pandas dependency, so we're just gonna go with catching the warning and ignoring parquet.