### PR TITLE
[REF] Removes .get_values() references

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -445,7 +445,7 @@ def get_expression_data(atlas, atlas_info=None, *, exact=True,
         expression += [group_by_label(samples, sample_labels,
                                       all_labels, metric=metric)]
         lgr.info('{:>3} / {} samples matched to ROIs for donor #{}'
-                 .format(np.sum(sample_labels.get_values() != 0),
+                 .format(np.sum(np.asarray(sample_labels) != 0),
                          len(annotation),
                          datasets.WELL_KNOWN_IDS.value_set('subj')[subj]))
 

--- a/abagen/mouse/mouse.py
+++ b/abagen/mouse/mouse.py
@@ -121,7 +121,7 @@ def _get_unionization_from_experiment(experiment_id, structures=None,
     # we need to coerce all provided structures to be integer ids, NOT strings
     # so fetch all available structures then recode them to ids
     if any(isinstance(f, str) for f in structures):
-        structs = fetch_allenref_structures(verbose=False).get_values()
+        structs = np.asarray(fetch_allenref_structures(verbose=False))
         structs = Recoder(structs.tolist(), fields=['acronym', 'id', 'name'])
         structures = list(set(structs.id.get(f) for f in structures))
 
@@ -263,7 +263,7 @@ def get_unionization_from_gene(id=None, acronym=None, name=None,
     # we need to coerce all provided structures to be integer ids, NOT strings
     # so fetch all available structures then recode them to ids
     if any(isinstance(f, str) for f in structures):
-        structs = fetch_allenref_structures(verbose=False).get_values()
+        structs = np.asarray(fetch_allenref_structures(verbose=False))
         structs = Recoder(structs.tolist(), fields=['acronym', 'id', 'name'])
         structures = list(set(structs.id.get(f) for f in structures))
 

--- a/abagen/mouse/mouse.py
+++ b/abagen/mouse/mouse.py
@@ -6,6 +6,7 @@ Functions to fetch mouse unionization (i.e., expression) data
 import itertools
 
 from nibabel.volumeutils import Recoder
+import numpy as np
 import pandas as pd
 
 from .io import fetch_allenref_structures, fetch_rubinov2015_structures

--- a/abagen/mouse/tests/test_mouse.py
+++ b/abagen/mouse/tests/test_mouse.py
@@ -74,7 +74,7 @@ def test_get_unionization_from_experiment(experiment, attributes):
 
     assert len(data.columns) == len(attributes)
     for attr in set(EXPERIMENTS[experiment].keys()).intersection(attributes):
-        assert np.allclose(data.loc[STRUCTURES, attr].get_values(),
+        assert np.allclose(np.asarray(data.loc[STRUCTURES, attr]),
                            EXPERIMENTS[experiment][attr])
 
 

--- a/abagen/mouse/tests/test_structure.py
+++ b/abagen/mouse/tests/test_structure.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import random
+import numpy as np
 import pytest
 from abagen.mouse import io, structure
 
@@ -52,11 +53,11 @@ def test_get_structure_info():
 def test_get_structure_coordinates(space):
     info = structure.get_structure_coordinates(id=1018,
                                                reference_space=space)
-    assert tuple(info[['x', 'y', 'z']].get_values()[0]) == COORD_ID[space]
+    assert tuple(np.asarray(info[['x', 'y', 'z']])[0]) == COORD_ID[space]
 
     info = structure.get_structure_coordinates(acronym='SSp',
                                                reference_space=space)
-    assert tuple(info[['x', 'y', 'z']].get_values()[0]) == COORD_ACRONYM[space]
+    assert tuple(np.asarray(info[['x', 'y', 'z']])[0]) == COORD_ACRONYM[space]
 
     # exception: structure is invalid
     with pytest.raises(ValueError):

--- a/abagen/process.py
+++ b/abagen/process.py
@@ -286,7 +286,7 @@ def _replace_mni_coords(annotation):
 
     annotation = io.read_annotation(annotation)
     mni_coords = _fetch_alleninf_coords().loc[annotation.well_id]
-    annotation[['mni_x', 'mni_y', 'mni_z']] = mni_coords.get_values()
+    annotation[['mni_x', 'mni_y', 'mni_z']] = np.asarray(mni_coords)
 
     return annotation
 
@@ -336,7 +336,7 @@ def normalize_expression(expression):
     """
 
     # get non-NaN values
-    data = expression.dropna(axis=0, how='all').get_values()
+    data = np.asarray(expression.dropna(axis=0, how='all'))
 
     # calculate sigmoid normalization
     norm = (data - np.median(data, axis=0)) / np.std(data, axis=0)


### PR DESCRIPTION
Closes #63 

Addresses pandas v0.25.0 deprecation warnings for `.get_values()` method on `Series` and `DataFrames`. Replaces all references with `numpy.asarray()`