### PR TITLE
[REF,ENH] Adds new abagen.probes module

### DIFF
--- a/abagen/probes.py
+++ b/abagen/probes.py
@@ -1,0 +1,577 @@
+# -*- coding: utf-8 -*-
+"""
+Functions for annotating / selecting microarray probes
+"""
+
+import functools
+import gzip
+from io import StringIO
+import itertools
+from pkg_resources import resource_filename
+
+import numpy as np
+import pandas as pd
+from sklearn.utils.extmath import svd_flip
+
+from . import io, utils
+
+
+def _groupby_and_apply(expression, probes, info, applyfunc):
+    """
+    Subsets `expression` based on most representative probe
+
+    Parameters
+    ----------
+    expression : list of (P, S) pandas.DataFrame
+        Each dataframe should have `P` rows representing probes and `S` columns
+        representing distinct samples, with values indicating microarray
+        expression levels
+    probes : pandas.DataFrame
+        Dataframe containing information on probes that should be considered in
+        representative analysis. Generally, intensity-based-filtering (i.e.,
+        `probe_ibf()`) should have been used to reduce this list to only those
+        probes with good expression signal
+    info : pandas.DataFrame
+        Dataframe containing information on probe expression information. Index
+        should be unique probe IDs and must have at least 'gene_symbol' column
+    applyfunc : callable
+        Function used to select representative probe ID from those indexing
+        the same gene. Must accept a pandas dataframe as input and return a
+        string (i.e., the chosen probe ID)
+
+    Returns
+    -------
+    representative : list of (S, G) pandas.DataFrame
+        Dataframes with rows representing `S` distinct samples and columns
+        representing `G` unique genes, with values indicating microarray
+        expression levels for each combination of samples and genes
+    """
+
+    # group probes by gene and get probe corresponding to max avg correlationx
+    retained = info.groupby('gene_symbol').apply(applyfunc)
+    probes = probes.loc[sorted(np.squeeze(retained).astype(int))]
+
+    # subset expression dataframes to retain only desired probes and reassign
+    # (and sort) index to gene symbols in lieu of probe IDs
+    representative = [
+        e.loc[probes.index].set_index(probes['gene_symbol']).sort_index()
+        for e in expression
+    ]
+
+    return representative
+
+
+def _max_idx(df):
+    """
+    Returns probe ID with max index in `df`
+
+    Parameters
+    ----------
+    df : (P, 1) pandas.DataFrame
+        Dataframe with `P` rows indicating distinct probes and one column
+        containing summary statistic of probe expression
+
+    Returns
+    -------
+    probe_id : str
+        ID of probe selected as representative for given gene
+    """
+
+    return df.idxmax()
+
+
+def _max_loading(df):
+    """
+    Returns probe ID with max loading along first principal component of `df`
+
+    Parameters
+    ----------
+    df : (P, S) pandas.DataFrame
+        Dataframe with `P` rows indicating distinct probe expression values
+        across `S` samples
+
+    Returns
+    -------
+    probe_id : str
+        ID of probe selected as representative for given gene
+    """
+
+    if len(df) == 1:
+        return df.iloc[0].name
+
+    # center data before SVD
+    data = np.asarray(df)
+    data = data - data.mean(axis=0, keepdims=True)
+
+    u, s, v = np.linalg.svd(data, full_matrices=False)
+    u, v = svd_flip(u, v)
+
+    return df.iloc[u[:, 0].argmax()].name
+
+
+def _wgcna(df, method):
+    """
+    Returns probe ID with max avg correlation (>2 probes) or `method` (<2)
+
+    Parameters
+    ----------
+    df : (P, S) pandas.DataFrame
+        Dataframe with `P` rows indicating distinct probe expression values
+        across `S` samples
+    method : {'variance', 'intensity'}
+        Method for selecting representative probe when only two probes index
+        the same gene (>2 probes uses correlation method)
+
+    Returns
+    -------
+    probe_id : str
+        ID of probe selected as representative for given gene
+    """
+
+    data = np.asarray(df)
+
+    if len(data) > 2:
+        xmax = np.mean((np.corrcoef(data) + 1) / 2, axis=1)
+    elif len(data) == 2:
+        if method == 'variance':
+            xmax = np.std(data, axis=1)
+        elif method == 'intensity':
+            xmax = np.mean(data, axis=1)
+    else:
+        xmax = np.array([0])
+
+    return df.iloc[xmax.argmax()].name
+
+
+def _diff_stability(expression, probes, annotation, *args, **kwargs):
+    """
+    Picks one probe to represent `expression` data for each gene in `probes`
+
+    If there are multiple probes with expression data for the same gene, this
+    function will calculate the similarity of each probes' expression across
+    donors and select the probe with the most consistent pattern of regional
+    variation (i.e., "differential stability" or DS). Regions are defined by
+    the "structure_id" column in `annotation`; similarity is calculated by the
+    Spearman correlation coefficient (but see `rank` kwarg).
+
+    Parameters
+    ----------
+    expression : list of (P, S) pandas.DataFrame
+        Each dataframe should have `P` rows representing probes and `S` columns
+        representing distinct samples, with values indicating microarray
+        expression levels
+    probes : pandas.DataFrame
+        Dataframe containing information on probes that should be considered in
+        representative analysis. Generally, intensity-based-filtering (i.e.,
+        `probe_ibf()`) should have been used to reduce this list to only those
+        probes with good expression signal
+    annotation : list of str
+        List of filepaths to annotation files from Allen Brain Institute (i.e.,
+        as obtained by calling :func:`abagen.fetch_microarray` and accessing
+        the `annotation` attribute on the resulting object).
+
+    Returns
+    -------
+    representative : list of (S, G) pandas.DataFrame
+        Dataframes with rows representing `S` distinct samples and columns
+        representing `G` unique genes, with values indicating microarray
+        expression levels for each combination of samples and genes
+    """
+
+    # collapse (i.e., average) expression across AHBA anatomical regions
+    region_exp = []
+    for exp, annot in zip(expression, annotation):
+        sid = io.read_annotation(annot)['structure_id']
+        exp = exp.rename(dict(zip(exp.columns, sid)), axis=1)
+        region_exp.append(exp.groupby(exp.columns, axis=1).mean())
+
+    # get correlation of probe expression across samples for all donor pairs
+    probe_exp = np.zeros((len(probes), sum(range(len(region_exp)))))
+    for n, (exp1, exp2) in enumerate(itertools.combinations(region_exp, 2)):
+
+        # samples that current donor pair have in common
+        samples = np.intersect1d(exp1.columns, exp2.columns)
+
+        # the ranking process can take a few seconds on each loop
+        # unfortunately, we have to do it each time because `samples` changes
+        # based on which anatomical regions the two subjects have in common
+        m1 = exp1.loc[:, samples].T.rank()
+        m2 = exp2.loc[:, samples].T.rank()
+
+        probe_exp[:, n] = utils.efficient_corr(m1, m2)
+
+    info = pd.DataFrame(dict(gene_symbol=np.asarray(probes.gene_symbol),
+                             diffstab=probe_exp.mean(axis=1)),
+                        index=probes.index)
+
+    return _groupby_and_apply(expression, probes, info, _max_idx)
+
+
+def _average(expression, probes, *args, **kwargs):
+    """
+    Averages expression data for probes representing the same gene
+
+    Parameters
+    ----------
+    expression : list of (P, S) pandas.DataFrame
+        Each dataframe should have `P` rows representing probes and `S` columns
+        representing distinct samples, with values indicating microarray
+        expression levels
+    probes : pandas.DataFrame
+        Dataframe containing information on probes that should be considered in
+        representative analysis. Generally, intensity-based-filtering (i.e.,
+        `probe_ibf()`) should have been used to reduce this list to only those
+        probes with good expression signal
+
+    Returns
+    -------
+    representative : list of (S, G) pandas.DataFrame
+        Dataframes with rows representing `S` distinct samples and columns
+        representing `G` unique genes, with values indicating microarray
+        expression levels for each combination of samples and genes
+    """
+
+    def _avg(df):
+        return df.join(probes['gene_symbol'], on='probe_id') \
+                 .groupby('gene_symbol') \
+                 .mean()
+
+    return [_avg(exp) for exp in expression]
+
+
+def _collapse(expression, probes, *args, method='variance', **kwargs):
+    """
+    Selects one representative probe per gene using provided `method`
+
+    Parameters
+    ----------
+    expression : list of (P, S) pandas.DataFrame
+        Each dataframe should have `P` rows representing probes and `S` columns
+        representing distinct samples, with values indicating microarray
+        expression levels
+    probes : pandas.DataFrame
+        Dataframe containing information on probes that should be considered in
+        representative analysis. Generally, intensity-based-filtering (i.e.,
+        `probe_ibf()`) should have been used to reduce this list to only those
+        probes with good expression signal
+    method : str, optional
+        Method by which to select represenative probes for each gene. Must be
+        one of ['max_variance', 'max_intensity', 'pc_loading', 'corr_variance',
+        'corr_intensity']
+
+    Returns
+    -------
+    representative : list of (S, G) pandas.DataFrame
+        Dataframes with rows representing `S` distinct samples and columns
+        representing `G` unique genes, with values indicating microarray
+        expression levels for each combination of samples and genes
+    """
+
+    # concatenate all donors into giant probe x sample expression dataframe
+    probe_exp = pd.concat(expression, axis=1)
+
+    # determine aggregation function based on provided method; also reduce
+    # probe expression if required (i.e., max_variance, max_intensity)
+    if method == 'max_variance':
+        probe_exp = probe_exp.std(axis=1)
+        probe_exp.name = method
+        agg = _max_idx
+    elif method == 'max_intensity':
+        probe_exp = probe_exp.mean(axis=1)
+        probe_exp.name = method
+        agg = _max_idx
+    elif method == 'pc_loading':
+        agg = _max_loading
+    elif method in ['corr_variance', 'corr_intensity']:
+        agg = functools.partial(_wgcna, method=method[5:])
+    else:
+        raise ValueError('Provided method {} invalid. Please check inputs '
+                         'and try again.'.format(method))
+
+    info = pd.merge(probes['gene_symbol'], probe_exp, on='probe_id')
+
+    return _groupby_and_apply(expression, probes, info, agg)
+
+
+_max_variance = functools.partial(_collapse, method='max_variance')
+_max_intensity = functools.partial(_collapse, method='max_intensity')
+_pc_loading = functools.partial(_collapse, method='pc_loading')
+_corr_variance = functools.partial(_collapse, method='corr_variance')
+_corr_intensity = functools.partial(_collapse, method='corr_intensity')
+
+
+SELECTION_METHODS = dict(
+    mean=_average,
+    average=_average,
+    max_intensity=_max_intensity,
+    max_variance=_max_variance,
+    pc_loading=_pc_loading,
+    corr_variance=_corr_variance,
+    corr_intensity=_corr_intensity,
+    diff_stability=_diff_stability
+)
+
+
+def collapse_probes(microarray, annotation, probes, method='diff_stability'):
+    """
+    Reduces `microarray` to a sample x gene expression dataframe
+
+    Using provided `method`, reduces `microarray` expression data by either (1)
+    selecting a representative probe amongst all probes indexing the same gene,
+    or (2) collapsing across all probes indexing the same gene. See Notes for
+    more information on different methods available.
+
+    Parameters
+    ----------
+    microarray : list of str
+        List of filepaths to microarray expression files from Allen Brain
+        Institute (i.e., as obtained by calling :func:`abagen.fetch_microarray`
+        and accessing the `microarray` attribute on the resulting object).
+    annotation : list of str
+        List of filepaths to annotation files from Allen Brain Institute (i.e.,
+        as obtained by calling :func:`abagen.fetch_microarray` and accessing
+        the `annotation` attribute on the resulting object). Only used if
+        provided `method` is 'diff_stability'
+    probes : pandas.DataFrame
+        Dataframe containing information on probes that should be considered in
+        representative analysis. Generally, intensity-based-filtering (i.e.,
+        `probe_ibf()`) should have been used to reduce this list to only those
+        probes with good expression signal
+    method : str, optional
+        Selection method for subsetting (or collapsing across) probes from the
+        same gene. Must be one of 'average', 'intensity', 'variance',
+        'pc_loading', 'corr_variance', 'corr_intensity', or 'diff_stability';
+        see Notes for more information. Default: 'diff_stability'
+
+    Returns
+    -------
+    expression : list of (S, G) pandas.DataFrame
+        Dataframes with rows representing `S` distinct samples and columns
+        representing `G` unique genes, with values indicating microarray
+        expression levels for each combination of samples and genes. Columns
+        will be identical across all dataframes but `S` will vary by donor.
+
+    Notes
+    -----
+    The following methods can be used for collapsing across probes when
+    multiple probes are available for the same gene.
+
+    1. ``method='average'``
+
+    Uses the average of expression data across probes indexing the same gene as
+    in [PR3]_, [PR5]_, [PR9]_, [PR10]_, [PR15]_, [PR16]_, and [PR17]_. Using
+    `method='mean'` will do the same thing.
+
+    2. ``method='max_intensity'``
+
+    Selects probe with maximum average expression across samples from all
+    donors as in [PR14]_.
+
+    3. ``method='max_variance'``
+
+    Selects probe with maximum variance in expression across samples from all
+    donors as in [PR12]_.
+
+    4. ``method='pc_loading'``
+
+    Selects probe with maximum loading on first principal component of
+    decomposition performed across samples from all donors as in [PR13]_.
+
+    5. ``method='corr_intensity'``
+
+    Selects probe with maximum correlation to other probes from same gene when
+    >2 probes exist; otherwise, uses same procedure as `method=max_intensity`.
+    Used in [PR1]_ and [PR11]_.
+
+    6. ``method='corr_variance'``
+
+    Selects probe with maximum correlation to other probes from same gene when
+    >2 probes exist; otherwise, uses same procedure as `method=max_variance`.
+    Used in [PR2]_, [PR4]_, and [PR6]_.
+
+    7. ``method='diff_stability'``
+
+    Selects probe with the most consistent pattern of regional variation across
+    donors (i.e., highest average correlation across brain regions between all
+    pairs of donors) as in [PR7]_ and [PR8]_.
+
+    References
+    ----------
+    .. [PR1] Anderson, K. M., Krienen, F. M., Choi, E. Y., Reinen, J. M., Yeo,
+    B. T., & Holmes, A. J. (2018). Gene expression links functional networks
+    across cortex and striatum. Nature Communications, 9(1), 1428.
+
+    .. [PR2] Burt, J. B., Demirtaş, M., Eckner, W. J., Navejar, N. M., Ji, J.
+    L., Martin, W. J., ... & Murray, J. D. (2018). Hierarchy of transcriptomic
+    specialization across human cortex captured by structural neuroimaging
+    topography. Nature Neuroscience, 21(9), 1251.
+
+    .. [PR3] Eising, E., Huisman, S. M., Mahfouz, A., Vijfhuizen, L. S.,
+    Anttila, V., Winsvold, B. S., ... & Boomsma, D. I. (2016). Gene
+    co-expression analysis identifies brain regions and cell types involved in
+    migraine pathophysiology: a GWAS-based study using the Allen Human Brain
+    Atlas. Human Genetics, 135(4), 425-439.
+
+    .. [PR4] Forest, M., Iturria‐Medina, Y., Goldman, J. S., Kleinman, C. L.,
+    Lovato, A., Oros Klein, K., ... & Greenwood, C. M. (2017). Gene networks
+    show associations with seed region connectivity. Human Brain Mapping,
+    38(6), 3126-3140.
+
+    .. [PR5] French, L., & Paus, T. (2015). A FreeSurfer view of the cortical
+    transcriptome generated from the Allen Human Brain Atlas. Frontiers in
+    Neuroscience, 9, 323.
+
+    .. [PR6] Hawrylycz, M. J., Lein, E. S., Guillozet-Bongaarts, A. L., Shen,
+    E. H., Ng, L., Miller, J. A., ... & Abajian, C. (2012). An anatomically
+    comprehensive atlas of the adult human brain transcriptome. Nature,
+    489(7416), 391.
+
+    .. [PR7] Hawrylycz, M., Miller, J. A., Menon, V., Feng, D., Dolbeare, T.,
+    Guillozet-Bongaarts, A. L., ... & Glasser, M. F. (2015). Canonical genetic
+    signatures of the adult human brain. Nature Neuroscience, 18(12), 1832.
+
+    .. [PR8] Kirsch, L., & Chechik, G. (2016). On expression patterns and
+    developmental origin of human brain regions. PLoS Computational Biology,
+    12(8), e1005064.
+
+    .. [PR9] Krienen, F. M., Yeo, B. T., Ge, T., Buckner, R. L., & Sherwood, C.
+    C. (2016). Transcriptional profiles of supragranular-enriched genes
+    associate with corticocortical network architecture in the human brain.
+    Proceedings of the National Academy of Sciences, 113(4), E469-E478.
+
+    .. [PR10] McColgan, P., Gregory, S., Seunarine, K. K., Razi, A., Papoutsi,
+    M., Johnson, E., ... & Scahill, R. I. (2018). Brain regions showing white
+    matter loss in Huntington’s disease are enriched for synaptic and metabolic
+    genes. Biological Psychiatry, 83(5), 456-465.
+
+    .. [PR11] Myers, E. M., Bartlett, C. W., Machiraju, R., & Bohland, J. W.
+    (2015). An integrative analysis of regional gene expression profiles in the
+    human brain. Methods, 73, 54-70.S
+
+    .. [PR12] Negi, S. K., & Guda, C. (2017). Global gene expression profiling
+    of healthy human brain and its application in studying neurological
+    disorders. Scientific Reports, 7(1), 897.
+
+    .. [PR13] Parkes, L., Fulcher, B. D., Yücel, M., & Fornito, A. (2017).
+    Transcriptional signatures of connectomic subregions of the human striatum.
+    Genes, Brain and Behavior, 16(7), 647-663.
+
+    .. [PR14] Romero-Garcia, R., Whitaker, K. J., Váša, F., Seidlitz, J.,
+    Shinn, M., Fonagy, P., ... & Vértes, P. E. (2018). Structural covariance
+    networks are coupled to expression of genes enriched in supragranular
+    layers of the human cortex. NeuroImage, 171, 256-267.
+
+    .. [PR15] Tan, P. P. C., French, L., & Pavlidis, P. (2013). Neuron-enriched
+    gene expression patterns are regionally anti-correlated with
+    oligodendrocyte-enriched patterns in the adult mouse and human brain.
+    Frontiers in Neuroscience, 7, 5.
+
+    .. [PR16] Vértes, P. E., Rittman, T., Whitaker, K. J., Romero-Garcia, R.,
+    Váša, F., Kitzbichler, M. G., ... & Goodyer, I. M. (2016). Gene
+    transcription profiles associated with inter-modular hubs and connection
+    distance in human functional magnetic resonance imaging networks.
+    Philosophical Transactions of the Royal Society B: Biological Sciences,
+    371(1705), 20150362.
+
+    .. [PR17] Whitaker, K. J., Vértes, P. E., Romero-Garcia, R., Váša, F.,
+    Moutoussis, M., Prabhu, G., ... & Tait, R. (2016). Adolescence is
+    associated with genomically patterned consolidation of the hubs of the
+    human brain connectome. Proceedings of the National Academy of Sciences,
+    113(32), 9105-9110.
+    """
+
+    try:
+        collfunc = SELECTION_METHODS[method]
+    except KeyError:
+        raise ValueError('Provided method must be one of {}, not: {}'
+                         .format(list(SELECTION_METHODS), method))
+
+    # read in microarray data for all subjects; this can be quite slow...
+    exp = [io.read_microarray(micro).loc[probes.index] for micro in microarray]
+
+    return [e.T for e in collfunc(exp, probes, annotation)]
+
+
+def reannotate_probes(probes):
+    """
+    Replaces gene symbols in `probes` with reannotated data
+
+    Uses annotations from [PR18]_ to replace probe annotations shipped with
+    AHBA data. Any probes that were unable to be matched to a gene in
+    reannotation procedure are not retained.
+
+    Parameters
+    ----------
+    probes : str or pandas.DataFrame
+        Probe file or loaded probe dataframe from Allen Brain Institute
+        containing information on microarray probes
+
+    Returns
+    -------
+    reannotated : pandas.DataFrame
+        Provided probe information with updated gene symbols and Entrez IDs
+
+    References
+    ----------
+    .. [PR18] Arnatkevic̆iūtė, A., Fulcher, B. D., & Fornito, A. (2019). A
+       practical guide to linking brain-wide gene expression and neuroimaging
+       data. NeuroImage, 189, 353-367.
+    """
+
+    # load in reannotated probes
+    reannot = resource_filename('abagen', 'data/reannotated.csv.gz')
+    with gzip.open(reannot, 'r') as src:
+        reannot = pd.read_csv(StringIO(src.read().decode('utf-8'))).iloc[:-1]
+    reannot = reannot[['probe_name', 'gene_symbol', 'entrez_id']]
+
+    # merge reannotated with original, keeping only reannotated
+    probes = io.read_probes(probes).reset_index()[['probe_name', 'probe_id']]
+    merged = pd.merge(reannot, probes, on='probe_name', how='left')
+
+    # reset index as probe_id and sort
+    reannotated = merged.set_index('probe_id').sort_index()
+
+    return reannotated
+
+
+def filter_probes(pacall, probes, threshold=0.5):
+    """
+    Performs intensity based filtering (IBF) of expression probes
+
+    Uses binary indicator for expression levels in `pacall` to determine which
+    probes have expression levels above background noise in `threshold` of
+    samples across donors.
+
+    Parameters
+    ----------
+    pacall : list of str
+        List of filepaths to PAcall files from Allen Brain Institute (i.e.,
+        as obtained by calling :func:`abagen.fetch_microarray` and accessing
+        the `pacall` attribute on the resulting object).
+    probes : str or pandas.DataFrame
+        Dataframe containing information on microarray probes that should be
+        considered in filtering (probes not in this dataframe will be ignored)
+    threshold : (0, 1) float, optional
+        Threshold for filtering probes. Specifies the proportion of samples for
+        which a given probe must have expression levels above background noise.
+        Default: 0.5
+
+    Returns
+    -------
+    filtered : pandas.DataFrame
+        Dataframe containing information on probes that should be retained
+        according to intensity-based filtering
+    """
+
+    probes = io.read_probes(probes)
+    signal, samples = [], 0
+    for fname in pacall:
+        data = io.read_pacall(fname).loc[probes.index]
+        samples += data.shape[-1]
+        # sum binary expression indicator across samples for current subject
+        signal.append(data.sum(axis=1).values)
+
+    # calculate proportion of signal to noise for given probe across samples
+    keep = (np.sum(signal, axis=0) / samples) > threshold
+
+    return probes[keep]

--- a/abagen/process.py
+++ b/abagen/process.py
@@ -2,15 +2,13 @@
 """
 Functions for cleaning and processing the AHBA microarray dataset
 """
-import gzip
-from io import StringIO
-import itertools
-from pkg_resources import resource_filename
+
 from nibabel.volumeutils import Recoder
 import numpy as np
 import pandas as pd
-from abagen import io, utils
-from abagen.datasets import _fetch_alleninf_coords
+
+from . import io, utils
+from .datasets import _fetch_alleninf_coords
 
 # AHBA structure IDs corresponding to different brain parts
 ONTOLOGY = Recoder(
@@ -23,196 +21,6 @@ ONTOLOGY = Recoder(
      ('9512', 'myelencephalon', 'cerebellum')),
     fields=('id', 'name', 'structure')
 )
-
-
-def reannotate_probes(probes):
-    """
-    Replaces gene symbols in `probes` with reannotated data
-
-    Uses annotations from [1]_ to replace probe annotations shipped with AHBA
-    data. Any probes that were unable to be matched to a gene in reannotation
-    procedure are not retained.
-
-    Parameters
-    ----------
-    probes : str or pandas.DataFrame
-        Probe file or loaded probe dataframe from Allen Brain Institute.
-        Optimally obtained by calling `abagen.fetch_microarray()` and accessing
-        the `probes` attribute on the resulting object
-
-    Returns
-    -------
-    reannotated : pandas.DataFrame
-
-
-    References
-    ----------
-    .. [1] Arnatkeviciute, A., Fulcher, B. D., & Fornito, A. (2018). A
-       practical guide to linking brain-wide gene expression and neuroimaging
-       data. bioRxiv, 380089.
-    """
-
-    # load in reannotated probes
-    reannot = resource_filename('abagen', 'data/reannotated.csv.gz')
-    with gzip.open(reannot, 'r') as src:
-        reannot = pd.read_csv(StringIO(src.read().decode('utf-8'))).iloc[:-1]
-    reannot = reannot[['probe_name', 'gene_symbol', 'entrez_id']]
-
-    # merge reannotated with original, keeping only reannotated
-    probes = io.read_probes(probes).reset_index()[['probe_name', 'probe_id']]
-    merged = pd.merge(reannot, probes, on='probe_name', how='left')
-
-    # reset index as probe_id and sort
-    reannotated = merged.set_index('probe_id').sort_index()
-
-    return reannotated
-
-
-def filter_probes(pacall, probes, threshold=0.5):
-    """
-    Performs intensity based filtering (IBF) of expression probes
-
-    Uses binary indicator for expression levels in `pacall` to determine which
-    probes have expression levels above background noise in `threshold` of
-    samples across donors.
-
-    Parameters
-    ----------
-    pacall : list
-        List of PACall files from Allen Brain Institute. Optimally obtained by
-        calling `abagen.fetch_microarray()` and accessing the `pacall`
-        attribute on the resulting object
-    probes : pandas.DataFrame
-        Dataframe containing information on genetic probes that should be
-        considered in filtering
-    threshold : (0, 1) float, optional
-        Threshold for filtering probes. Specifies the proportion of samples for
-        which a given probe must have expression levels above background noise.
-        Default: 0.5
-
-    Returns
-    -------
-    filtered : pandas.DataFrame
-        Dataframe containing information on probes that should be retained
-        according to intensity-based filtering
-    """
-
-    probes = io.read_probes(probes)
-    signal, samples = [], 0
-    for fname in pacall:
-        data = io.read_pacall(fname).loc[probes.index]
-        samples += data.shape[-1]
-        # sum binary expression indicator across samples for current subject
-        signal.append(data.sum(axis=1).values)
-
-    # calculate proportion of signal to noise for given probe across samples
-    keep = (np.sum(signal, axis=0) / samples) > threshold
-
-    # drop "bad" probes
-    filtered = probes[keep]
-
-    return filtered
-
-
-def get_stable_probes(microarray, annotation, probes):
-    """
-    Picks one probe to represent `microarray` data for each gene in `probes`
-
-    If there are multiple probes with expression data for the same gene, this
-    function will calculate the similarity of each probes' expression across
-    donors and select the probe with the most consistent pattern of regional
-    variation (i.e., "differential stability" or DS). Regions are defined by
-    the "structure_id" column in `annotation`; similarity is calculated by the
-    Spearman correlation coefficient.
-
-    Parameters
-    ----------
-    microarray : list of str
-        List of microarray expression files from Allen Brain Institute.
-        Optimally obtained by calling `abagen.fetch_microarray()` and accessing
-        the `microarray` attribute on the resulting object.
-    annotation : list of str
-        List of annotation files from Allen Brain Institute. Optimally obtained
-        by calling `abagen.fetch_microarray()` and accessing the `annotation`
-        attribute on the resulting object.
-    probes : pandas.DataFrame
-        Dataframe containing information on probes that should be considered in
-        representative analysis. Generally, intensity-based-filtering (i.e.,
-        `probe_ibf()`) should have been used to reduce this list to only those
-        probes with good expression signal
-
-    Returns
-    -------
-    representative : pandas.DataFrame
-        Dataframe containing information on probes that are most representative
-        of their genes based on differential stability analysis
-
-    References
-    ----------
-    Hawrylycz, M., Miller, J. A., Menon, V., Feng, D., Dolbeare, T., Guillozet-
-    Bongaarts, A. L., ... & Lein, E. (2015). Canonical genetic signatures of
-    the adult human brain. Nature Neuroscience, 18(12), 1832.
-    """
-
-    # read in microarray data for all subjects
-    num_subj = len(microarray)
-
-    # this is a relatively slow procedure (i.e., takes a couple of seconds)
-    micro = [_reduce_micro(microarray[n], annotation[n], probes)
-             for n in range(num_subj)]
-
-    # get correlation of probe expression across samples for all donor pairs
-    probe_corrs = np.zeros((len(probes), sum(range(num_subj))))
-    for n, (s1, s2) in enumerate(itertools.combinations(range(num_subj), 2)):
-
-        # find samples that current donor pair have in common
-        samples = np.intersect1d(micro[s1].columns, micro[s2].columns)
-
-        # the ranking process can take a few seconds on each loop
-        # unfortunately, we have to do it each time because `samples` changes
-        probe_corrs[:, n] = utils.efficient_corr(micro[s1][samples].T.rank(),
-                                                 micro[s2][samples].T.rank())
-
-    # group probes by gene and get probe corresponding to max correlation
-    df = pd.DataFrame(dict(gene_symbol=probes.gene_symbol.values,
-                           corrs=probe_corrs.mean(axis=1),
-                           probe_id=probes.index))
-    retained = (df.groupby('gene_symbol')
-                  .apply(lambda x: x.loc[x.corrs.idxmax(), 'probe_id']))
-
-    return probes[probes.index.isin(retained.values)]
-
-
-def _reduce_micro(micro, annot, probes):
-    """
-    Collapse expression data in `micro` taken from same anatomical structure
-
-    Parameters
-    ----------
-    micro : str
-        Filepath to microarray file for single donor
-    annot : str
-        Filepath to annotation file for single donor; should be same donor as
-        `micro`
-    probes : pandas.DataFrame
-        Probes that should be considered for analysis (i.e., those that made it
-        through intensity-based filtering)
-
-    Returns
-    -------
-    micro : (P x S) pd.core.frame.DataFrame
-        Microarray expression data, where `P` is probes and `S` is anatomical
-        structures
-    """
-    # read in microarray data and set columns as anatomical structure ID
-    micro = io.read_microarray(micro)
-    micro.columns = io.read_annotation(annot).structure_id
-
-    # average across same structures
-    micro = micro.groupby(micro.columns, axis=1).mean()
-
-    # only keep good probes
-    return micro[micro.index.isin(probes.index)]
 
 
 def drop_mismatch_samples(annotation, ontology, corrected=True):
@@ -251,18 +59,18 @@ def drop_mismatch_samples(annotation, ontology, corrected=True):
     ont = io.read_ontology(ontology)
 
     # add hemisphere + brain "structure" designation to annotation data
-    hemi = dict(zip(ont.id, ont.hemisphere))
-    stru = dict(zip(ont.id, ont.structure_id_path.apply(_get_path_structure)))
-    annot = annot.assign(hemisphere=annot.structure_id.replace(hemi),
-                         structure=annot.structure_id.replace(stru))
+    hemi = dict(zip(ont['id'], ont['hemisphere']))
+    stru = dict(zip(ont['id'], ont['structure_id_path'].apply(_get_struct)))
+    annot = annot.assign(hemisphere=annot['structure_id'].replace(hemi),
+                         structure=annot['structure_id'].replace(stru))
 
     # correct MNI coordinates, if requested
     if corrected:
         annot = _replace_mni_coords(annot)
 
     # only keep samples with consistent hemisphere + MNI coordinate designation
-    keep = annot.query('(hemisphere == "L" & mni_x < 0) | '
-                       '(hemisphere == "R" & mni_x > 0)')
+    keep = annot.query('(hemisphere == "L" & mni_x < 0)'
+                       '| (hemisphere == "R" & mni_x > 0)')
 
     return keep
 
@@ -291,7 +99,7 @@ def _replace_mni_coords(annotation):
     return annotation
 
 
-def _get_path_structure(structure_path):
+def _get_struct(structure_path):
     """
     Gets overarching "structure" of region defined by `structure_path`
 
@@ -310,6 +118,7 @@ def _get_path_structure(structure_path):
     structure : str
         One of ['cortex', 'subcortex', 'cerebellum'] or None
     """
+
     structure_path = set(structure_path.split('/'))
     ids = list(set(ONTOLOGY.value_set('id')).intersection(structure_path))
 

--- a/abagen/tests/test_probes.py
+++ b/abagen/tests/test_probes.py
@@ -27,52 +27,67 @@ def test_reannotate_probes(testfiles):
     assert reannot.shape == (45892, 3)
 
 
-def test_filter_probes(testfiles):
+@pytest.mark.parametrize('threshold, expected_length', [
+    # threshold of zero should just return the full probe dataframe
+    (0.0, 58692),
+    # default threshold
+    (0.5, 38176),
+    # threshold of one should NOT return an empty dataframe (that's useless)
+    # this will return all the probes that are greater than background noise
+    # across ALL samples from ALL provided donors
+    (1.0, 11878),
+    # threshold is clipped to [0, 1] so these should be identical to [0, 1]
+    (-1.0, 58692),
+    (2.0, 11878),
+])
+def test_filter_probes(testfiles, threshold, expected_length):
     # set up a few useful variables
     pacall = testfiles['pacall']
     probe_file = testfiles['probes'][0]
     probe_df = abagen.io.read_probes(probe_file)
 
     # should work with either a filename _or_ a dataframe
-    filtered = probes.filter_probes(pacall, probe_file)
+    filtered = probes.filter_probes(pacall, probe_file, threshold=threshold)
     pd.testing.assert_frame_equal(
         filtered,
-        probes.filter_probes(pacall, probe_df)
+        probes.filter_probes(pacall, probe_df, threshold=threshold)
     )
 
-    # expected output with default threshold
+    # provided threshold returns expected output
     cols = [
-        'probe_name', 'gene_id', 'gene_symbol',
-        'gene_name', 'entrez_id', 'chromosome'
+        'probe_name', 'gene_id', 'gene_symbol', 'gene_name', 'entrez_id',
+        'chromosome'
     ]
     assert np.all(filtered.columns == cols)
     assert filtered.index.name == 'probe_id'
-    assert filtered.shape == (38176, 6)
-
-    # threshold of zero should just return the full probe dataframe
-    no_filter = probes.filter_probes(pacall, probe_file, threshold=0.0)
-    assert len(no_filter) == len(probe_df)
-
-    # threshold of one should NOT return an empty dataframe (that's useless)
-    # this will return all the probes that are greater than background noise
-    # across ALL samples from ALL provided donors
-    max_filter = probes.filter_probes(pacall, probe_file, threshold=1.0)
-    assert len(max_filter) == 11878
-
-    # threshold is clipped to the (0, 1) range, so ensure equivalence w/above
-    below = probes.filter_probes(pacall, probe_file, threshold=-1.0)
-    pd.testing.assert_frame_equal(no_filter, below)
-    above = probes.filter_probes(pacall, probe_file, threshold=2.0)
-    pd.testing.assert_frame_equal(max_filter, above)
+    assert len(filtered) == expected_length
 
 
-@pytest.mark.xfail(run=False)
-def test_groupby_and_apply():
-    assert False
+@pytest.mark.parametrize('func, a_expected, b_expected', [
+    (probes._max_idx, [2, 4, 5], [10, 8, 7]),
+    (lambda x: x.index[0], [0, 3, 5], [12, 9, 7]),
+])
+def test_groupby_and_apply(func, a_expected, b_expected):
+    # lots of set up for this little function...
+    index = pd.Series([1000, 2000, 3000, 4000, 5000, 6000], name='probe_id')
+    gene_symbol = ['a', 'a', 'a', 'b', 'b', 'c']
+    info = pd.DataFrame(dict(gene_symbol=gene_symbol,
+                             a=range(6),
+                             b=range(12, 6, -1)),
+                        index=index)
+    prb = pd.DataFrame(dict(gene_symbol=gene_symbol), index=index)
+    exp = [info[['a', 'b']].copy()]
+
+    mi = probes._groupby_and_apply(exp, prb, info, func)[0]
+    expected = pd.DataFrame(dict(a=a_expected, b=b_expected),
+                            index=pd.Series(['a', 'b', 'c'],
+                                            name='gene_symbol'))
+    pd.testing.assert_frame_equal(mi, expected)
 
 
 def test_max_idx():
-    df = pd.DataFrame(dict(a=[1, 2, 3], b=[6, 5, 4]),
+    df = pd.DataFrame(dict(a=[1, 2, 3],
+                           b=[6, 5, 4]),
                       index=['one', 'two', 'three'])
 
     # should return max index of column specified
@@ -87,76 +102,137 @@ def test_max_idx():
     assert probes._max_idx(dfa, column='a') == 'three'
     assert probes._max_idx(dfa) == 'three'
 
-    # string column anywhere in dataframe is bad
+    # string column anywhere in dataframe is bad news bears
     with pytest.raises(TypeError):
         df['b'] = df['b'].astype(str)
         probes._max_idx(df)
 
 
-def test_max_loading():
+@pytest.mark.parametrize('angles, index', [
+    (np.arange(0, 360, 15), 0),
+    (np.arange(180, -180, -15), 12),
+])
+def test_max_loading(angles, index):
     def _get_ellipse_coords(ang, a=2, b=0.5, origin=(0, 0), rotate=0):
         # convert to radians
-        ang = ang * (np.pi / 180)
-        rotate = rotate * (np.pi / 180)
+        rad = np.pi / 180
+        ang, rotate = ang * rad, rotate * rad
+        cang, sang = np.cos(ang), np.sin(ang)
+        crot, srot = np.cos(rotate), np.sin(rotate)
 
         # calculate new points
-        x = (a * np.cos(ang) * np.cos(rotate)) \
-            - (b * np.sin(ang) * np.sin(rotate)) \
-            + origin[0]
-        y = (a * np.cos(ang) * np.sin(rotate)) \
-            + (b * np.sin(ang) * np.cos(rotate)) \
-            + origin[1]
+        x = (a * cang * crot) - (b * sang * srot) + origin[0]
+        y = (a * cang * srot) + (b * sang * crot) + origin[1]
 
-        return (x, y)
+        return x, y
 
-    # grab a few points from a rotated ellipse and make a dataframe
-    angles = np.arange(0, 360, 45)
-    ellipse = np.row_stack([_get_ellipse_coords(f, rotate=45) for f in angles])
-    df = pd.DataFrame(ellipse)
-
-    assert probes._max_loading(df) == 0
+    # grab a few points from a rotated ellipse and make a dataframe of it
+    # the max loading should be wherever angle = 0
+    df = pd.DataFrame([_get_ellipse_coords(f, rotate=45) for f in angles])
+    assert probes._max_loading(df) == index
 
 
-def test_correlate():
+@pytest.mark.parametrize('from_row, method, expected', [
+    # when there are >2 rows the provided method is ignored
+    (0, 'variance', 'one'),
+    (0, 'intensity', 'one'),
+    # when there are exactly two rows we use the specified method
+    (1, 'variance', 'two'),
+    (1, 'intensity', 'three'),
+    # and one row just returns the index of that row
+    (2, 'variance', 'three'),
+    (2, 'variance', 'three'),
+])
+def test_correlate(from_row, method, expected):
     df = pd.DataFrame(dict(a=[1.50, 1, 3],   # maximum correlation
                            b=[2.00, 2, 3],   # maximum variance
                            c=[2.75, 3, 4]),  # maximum intensity
                       index=['one', 'two', 'three'])
 
-    # when there are >2 rows the provided method is ignored
-    assert probes._correlate(df, method='variance') == 'one'
-    assert probes._correlate(df, method='intensity') == 'one'
-
-    # when there are exactly two rows we use the specified method
-    df = df.iloc[1:]
-    assert probes._correlate(df, method='variance') == 'two'
-    assert probes._correlate(df, method='intensity') == 'three'
-
-    # and one row just returns the index of that row
-    df = df.iloc[1:]
-    assert probes._correlate(df, method='variance') == 'three'
-    assert probes._correlate(df, method='intensity') == 'three'
+    assert probes._correlate(df.iloc[from_row:], method=method) == expected
 
 
-@pytest.mark.xfail(run=False)
-def test_diff_stability(testfiles):
-    assert False
+def test_diff_stability():
+    # so much set up...
+    index = pd.Series([1000, 2000, 3000, 4000, 5000, 6000], name='probe_id')
+    prb = pd.DataFrame(dict(gene_symbol=['a', 'a', 'a', 'b', 'b', 'c']),
+                       index=index)
+    expression = [
+        pd.DataFrame(dict(one=[0, 1, 2, 3, 4, 5],
+                          two=[2, 3, 4, 5, 6, 7],
+                          three=[4, 3, 4, 1, 6, 3],
+                          four=[9, 2, 1, 0, 7, 4]), index=index),
+        pd.DataFrame(dict(one=[1, 3, 1, 1, 1, 1],
+                          two=[2, 2, 3, 3, 2, 2],
+                          three=[3, 1, 2, 2, 3, 3]), index=index)
+    ]
+
+    annotation = [
+        pd.DataFrame(dict(structure_id=[0, 0, 1, 2]),
+                     index=expression[0].columns),
+        pd.DataFrame(dict(structure_id=[0, 1, 2]),
+                     index=expression[1].columns)
+    ]
+
+    expected = [
+        pd.DataFrame([[0, 2, 4, 9],
+                      [4, 6, 6, 7],
+                      [5, 7, 3, 4]],
+                     index=pd.Series(['a', 'b', 'c'], name='gene_symbol'),
+                     columns=expression[0].columns),
+        pd.DataFrame([[1, 2, 3],
+                      [1, 2, 3],
+                      [1, 2, 3]],
+                     index=pd.Series(['a', 'b', 'c'], name='gene_symbol'),
+                     columns=expression[1].columns),
+    ]
+
+    out = probes._diff_stability(expression, prb, annotation)
+    assert len(out) == len(expected)
+    for df, exp in zip(out, expected):
+        pd.testing.assert_frame_equal(df, exp)
 
 
-@pytest.mark.xfail(run=False)
 def test_average():
-    assert False
+    index = pd.Series([1000, 2000, 3000, 4000, 5000, 6000], name='probe_id')
+    prb = pd.DataFrame(dict(gene_symbol=['a', 'a', 'a', 'b', 'b', 'c']),
+                       index=index)
+    exp = [pd.DataFrame(dict(a=range(6),
+                             b=range(12, 6, -1)),
+                        index=index)]
+
+    # output should be a list of dataframes (only one dataframe in this case)
+    out = probes._average(exp, prb)
+    assert len(out) == 1
+    out = out[0]
+
+    # confirm output dataframe is as expected
+    expected = pd.DataFrame(dict(a=[1.0, 3.5, 5.0],
+                                 b=[11.0, 8.5, 7.0]),
+                            index=pd.Series(['a', 'b', 'c'],
+                                            name='gene_symbol'))
+    pd.testing.assert_frame_equal(out, expected)
 
 
 @pytest.mark.parametrize('method', [
     'average',
+    'mean',
     'max_intensity',
     'max_variance',
     'pc_loading',
     'corr_intensity',
     'corr_variance',
-    'diff_stability'
+    'diff_stability',
 ])
-@pytest.mark.xfail(run=False)
 def test_collapse_probes(testfiles, method):
-    assert False
+    # we've aleady tested the underlying methods so here we just want to do
+    # some smoke tests to make sure the function returns what we expected
+    # regardless of the provided method
+    out = probes.collapse_probes(testfiles['microarray'],
+                                 testfiles['annotation'],
+                                 testfiles['probes'][0],
+                                 method=method)
+
+    assert len(out) == 2  # number of donors
+    assert np.all([len(exp) == n_samp for exp, n_samp in zip(out, [363, 470])])
+    assert np.all([len(exp.columns) == 29131 for exp in out])

--- a/abagen/tests/test_probes.py
+++ b/abagen/tests/test_probes.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for abagen.probes module
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import abagen
+from abagen import probes
+
+
+def test_reannotate_probes(testfiles):
+    # set up a few useful variables
+    probe_file = testfiles['probes'][0]
+
+    # should work with either a filename _or_ a dataframe
+    reannot = probes.reannotate_probes(probe_file)
+    probe_df = abagen.io.read_probes(probe_file)
+    pd.testing.assert_frame_equal(reannot, probes.reannotate_probes(probe_df))
+
+    # expected output
+    cols = ['probe_name', 'gene_symbol', 'entrez_id']
+    assert np.all(reannot.columns == cols)
+    assert reannot.index.name == 'probe_id'
+    assert reannot.shape == (45892, 3)
+
+
+def test_filter_probes(testfiles):
+    # set up a few useful variables
+    pacall = testfiles['pacall']
+    probe_file = testfiles['probes'][0]
+    probe_df = abagen.io.read_probes(probe_file)
+
+    # should work with either a filename _or_ a dataframe
+    filtered = probes.filter_probes(pacall, probe_file)
+    pd.testing.assert_frame_equal(
+        filtered,
+        probes.filter_probes(pacall, probe_df)
+    )
+
+    # expected output with default threshold
+    cols = [
+        'probe_name', 'gene_id', 'gene_symbol',
+        'gene_name', 'entrez_id', 'chromosome'
+    ]
+    assert np.all(filtered.columns == cols)
+    assert filtered.index.name == 'probe_id'
+    assert filtered.shape == (38176, 6)
+
+    # threshold of zero should just return the full probe dataframe
+    no_filter = probes.filter_probes(pacall, probe_file, threshold=0.0)
+    assert len(no_filter) == len(probe_df)
+
+    # threshold of one should NOT return an empty dataframe (that's useless)
+    # this will return all the probes that are greater than background noise
+    # across ALL samples from ALL provided donors
+    max_filter = probes.filter_probes(pacall, probe_file, threshold=1.0)
+    assert len(max_filter) == 11878
+
+    # threshold is clipped to the (0, 1) range, so ensure equivalence w/above
+    below = probes.filter_probes(pacall, probe_file, threshold=-1.0)
+    pd.testing.assert_frame_equal(no_filter, below)
+    above = probes.filter_probes(pacall, probe_file, threshold=2.0)
+    pd.testing.assert_frame_equal(max_filter, above)
+
+
+@pytest.mark.xfail(run=False)
+def test_groupby_and_apply():
+    assert False
+
+
+def test_max_idx():
+    df = pd.DataFrame(dict(a=[1, 2, 3], b=[6, 5, 4]),
+                      index=['one', 'two', 'three'])
+
+    # should return max index of column specified
+    assert probes._max_idx(df, column='a') == 'three'
+    assert probes._max_idx(df, column='b') == 'one'
+
+    # not specifying column should use first numerical column (i.e., 'a')
+    assert probes._max_idx(df) == 'three'
+
+    # what if we only have a single column dataframe?
+    dfa = df[['a']]
+    assert probes._max_idx(dfa, column='a') == 'three'
+    assert probes._max_idx(dfa) == 'three'
+
+    # string column anywhere in dataframe is bad
+    with pytest.raises(TypeError):
+        df['b'] = df['b'].astype(str)
+        probes._max_idx(df)
+
+
+def test_max_loading():
+    def _get_ellipse_coords(ang, a=2, b=0.5, origin=(0, 0), rotate=0):
+        # convert to radians
+        ang = ang * (np.pi / 180)
+        rotate = rotate * (np.pi / 180)
+
+        # calculate new points
+        x = (a * np.cos(ang) * np.cos(rotate)) \
+            - (b * np.sin(ang) * np.sin(rotate)) \
+            + origin[0]
+        y = (a * np.cos(ang) * np.sin(rotate)) \
+            + (b * np.sin(ang) * np.cos(rotate)) \
+            + origin[1]
+
+        return (x, y)
+
+    # grab a few points from a rotated ellipse and make a dataframe
+    angles = np.arange(0, 360, 45)
+    ellipse = np.row_stack([_get_ellipse_coords(f, rotate=45) for f in angles])
+    df = pd.DataFrame(ellipse)
+
+    assert probes._max_loading(df) == 0
+
+
+def test_correlate():
+    df = pd.DataFrame(dict(a=[1.50, 1, 3],   # maximum correlation
+                           b=[2.00, 2, 3],   # maximum variance
+                           c=[2.75, 3, 4]),  # maximum intensity
+                      index=['one', 'two', 'three'])
+
+    # when there are >2 rows the provided method is ignored
+    assert probes._correlate(df, method='variance') == 'one'
+    assert probes._correlate(df, method='intensity') == 'one'
+
+    # when there are exactly two rows we use the specified method
+    df = df.iloc[1:]
+    assert probes._correlate(df, method='variance') == 'two'
+    assert probes._correlate(df, method='intensity') == 'three'
+
+    # and one row just returns the index of that row
+    df = df.iloc[1:]
+    assert probes._correlate(df, method='variance') == 'three'
+    assert probes._correlate(df, method='intensity') == 'three'
+
+
+@pytest.mark.xfail(run=False)
+def test_diff_stability(testfiles):
+    assert False
+
+
+@pytest.mark.xfail(run=False)
+def test_average():
+    assert False
+
+
+@pytest.mark.parametrize('method', [
+    'average',
+    'max_intensity',
+    'max_variance',
+    'pc_loading',
+    'corr_intensity',
+    'corr_variance',
+    'diff_stability'
+])
+@pytest.mark.xfail(run=False)
+def test_collapse_probes(testfiles, method):
+    assert False

--- a/abagen/tests/test_probes.py
+++ b/abagen/tests/test_probes.py
@@ -144,10 +144,11 @@ def test_max_loading(angles, index):
     (2, 'variance', 'three'),
 ])
 def test_correlate(from_row, method, expected):
-    df = pd.DataFrame(dict(a=[1.50, 1, 3],   # maximum correlation
-                           b=[2.00, 2, 3],   # maximum variance
-                           c=[2.75, 3, 4]),  # maximum intensity
-                      index=['one', 'two', 'three'])
+    # a = max correlation, b = max variance, c = max intensity
+    df = pd.DataFrame([[1.50, 2.00, 2.75],
+                       [1.00, 2.00, 3.00],
+                       [3.00, 3.00, 4.00]],
+                      index=['one', 'two', 'three'], columns=['a', 'b', 'c'])
 
     assert probes._correlate(df.iloc[from_row:], method=method) == expected
 
@@ -158,13 +159,20 @@ def test_diff_stability():
     prb = pd.DataFrame(dict(gene_symbol=['a', 'a', 'a', 'b', 'b', 'c']),
                        index=index)
     expression = [
-        pd.DataFrame(dict(one=[0, 1, 2, 3, 4, 5],
-                          two=[2, 3, 4, 5, 6, 7],
-                          three=[4, 3, 4, 1, 6, 3],
-                          four=[9, 2, 1, 0, 7, 4]), index=index),
-        pd.DataFrame(dict(one=[1, 3, 1, 1, 1, 1],
-                          two=[2, 2, 3, 3, 2, 2],
-                          three=[3, 1, 2, 2, 3, 3]), index=index)
+        pd.DataFrame([[0, 2, 4, 9],
+                      [1, 3, 3, 2],
+                      [2, 4, 4, 1],
+                      [3, 5, 1, 0],
+                      [4, 6, 6, 7],
+                      [5, 7, 3, 4]],
+                     index=index, columns=['one', 'two', 'three', 'four']),
+        pd.DataFrame([[1, 2, 3],
+                      [3, 2, 1],
+                      [1, 3, 2],
+                      [1, 3, 2],
+                      [1, 2, 3],
+                      [1, 2, 3]],
+                     index=index, columns=['one', 'two', 'three'])
     ]
 
     annotation = [
@@ -197,9 +205,8 @@ def test_average():
     index = pd.Series([1000, 2000, 3000, 4000, 5000, 6000], name='probe_id')
     prb = pd.DataFrame(dict(gene_symbol=['a', 'a', 'a', 'b', 'b', 'c']),
                        index=index)
-    exp = [pd.DataFrame(dict(a=range(6),
-                             b=range(12, 6, -1)),
-                        index=index)]
+    exp = [pd.DataFrame([[0, 12], [1, 11], [2, 10], [3, 9], [4, 8], [5, 7]],
+                        index=index, columns=['a', 'b'])]
 
     # output should be a list of dataframes (only one dataframe in this case)
     out = probes._average(exp, prb)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE
+xfail_strict = true
+addopts = -rx


### PR DESCRIPTION
Closes #51.

Moves all functions operating on probes to `abagen.probes` module (i.e., `reannotate_probes()` and `filter_probes()`, previously in `abagen.process`) and adds new probe selection methods (previously limited to differential stability).

New selection methods have been integrated into primary workflow (i.e., `abagen.get_expression()`) via the optional `probe_selection` keyword argument. Relevant references and description of the different methods have been added to the Notes of the doc-strings.

To do:
- [ ] Add tests for all new probe selection methods
- [ ] Update docs to reflect new options