### PR TITLE
[REF] Adds brainstem to abagen.process ontology

### DIFF
--- a/abagen/process.py
+++ b/abagen/process.py
@@ -17,8 +17,10 @@ ONTOLOGY = Recoder(
      ('4391', 'diencephalon', 'subcortex'),
      ('9001', 'mesencephalon', 'subcortex'),
      ('4696', 'cerebellum', 'cerebellum'),
-     ('4833', 'metencephalon', 'cerebellum'),
-     ('9512', 'myelencephalon', 'cerebellum')),
+     ('9131', 'pons', 'brainstem'),
+     ('9512', 'myelencephalon', 'brainstem'),
+     ('9218', 'white matter', 'white matter'),
+     ('9352', 'sulci & spaces', 'other')),
     fields=('id', 'name', 'structure')
 )
 

--- a/docs/user_guide/parcellations.rst
+++ b/docs/user_guide/parcellations.rst
@@ -40,7 +40,8 @@ must ensure it has the following columns:
   1. ``id``: an integer ID corresponding to the labels in the ``atlas`` image
   2. ``hemisphere``: a L/R hemispheric designation (i.e., 'L' or 'R')
   3. ``structure``: a broad structural class designation (i.e., one of
-     'cortex', 'subcortex', or 'cerebellum')
+     'cortex', 'subcortex', 'cerebellum', 'brainstem', 'white matter', or
+     'other')
 
 For example, a valid CSV might look like this:
 
@@ -55,6 +56,6 @@ For example, a valid CSV might look like this:
     3   4   medialorbitofrontal_rh          R    cortex
     4   5      parstriangularis_rh          R    cortex
 
-Notice that extra columns (i.e., ``label``) are okay, as long as the three
+Notice that extra columns (i.e., ``label``) are okay as long as the three
 required columns are present! If you want to confirm your file is formatted
 correctly you can use :func:`abagen.utils.check_atlas_info()`.


### PR DESCRIPTION
Closes #79.

Adds brainstem (and other) structures to `abagen.process.ONTOLOGY` dictionary for better matching with structural classes when users provide an `atlas_info` argument to `abagen.get_expression_data()`.

To Do:
- [x] Update documentation to reflect these new structures for `atlas_info` arguments