### PR TITLE
[ENH] Adds CLI for `abagen.get_expression_data` functionality

### DIFF
--- a/abagen/cli/run.py
+++ b/abagen/cli/run.py
@@ -1,33 +1,108 @@
 # -*- coding: utf-8 -*-
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter, SUPPRESS
+import logging
+import os
 from pathlib import Path
 import sys
 
-from ..allen import get_expression_data
+lgr = logging.getLogger('abagen')
+
+
+def _resolve_path(path):
+    """ Helper function for get_parser() to resolve paths
+    """
+
+    if path is not None:
+        return str(Path(path).expanduser().resolve())
 
 
 def get_parser():
-    from ..info import __version__
+    """ Gets command-line arguments for primary get_expression_data workflow
+    """
+
+    from .. import __version__
 
     verstr = 'abagen v{}'.format(__version__)
-    parser = ArgumentParser(description='')
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
+                            description="""
+Assigns microarray expression data to ROIs defined in the specific `atlas`
 
-    parser.add_argument('atlas', action='store', type=Path,
-                        help='An image in MNI space, where each parcel in the'
+This command aims to provide a workflow for generating pre-processed microarray
+expression data from the Allen Human Brain Atlas for arbitrary atlas
+designations. First, some basic filtering of genetic probes is performed,
+including:
+
+    1. Intensity-based filtering of microarray probes to remove probes that do
+       not exceed a certain level of background noise (specified via the
+       `ibf_threshold` parameter), and
+    2. Selection of a single, representative probe (or collapsing across
+       probes) for each gene, specified via the `probe_selection` parameter.
+
+Tissue samples are then matched to parcels in the defined `atlas` for each
+donor. If `atlas_info` is provided then this matching is constrained by both
+hemisphere and tissue class designation (e.g., cortical samples from the left
+hemisphere are only matched to ROIs in the left cortex, subcortical samples
+from the right hemisphere are only matched to ROIs in the left subcortex); see
+the `atlas_info` parameter description for more information.
+
+Matching of microarray samples to parcels in `atlas` is done via a multi-step
+process:
+
+    1. Determine if the sample falls directly within a parcel,
+    2. Check to see if there are nearby parcels by slowly expanding the search
+       space to include nearby voxels, up to a specified distance (specified
+       via the `tolerance` parameter),
+    3. If there are multiple nearby parcels, the sample is assigned to the
+       closest parcel, as determined by the parcel centroid.
+
+If at any step a sample can be assigned to a parcel the matching process is
+terminated. If multiple sample are assigned to the same parcel they are
+aggregated with the metric specified via the `metric` parameter. More control
+over the sample matching can be obtained by setting the `inexact` parameter;
+see the parameter description for more information.
+
+Once all samples have been matched to parcels for all supplied donors, the
+microarray expression data are normalized within-donor via a scaled robust
+sigmoid (SRS) procedure before being combined across donors via the supplied
+`metric`.
+""")
+
+    parser.add_argument('atlas', action='store', type=_resolve_path,
+                        help='An image in MNI space, where each parcel in the '
                              'image is identified by a unique integer ID.')
 
     parser.add_argument('--version', action='version', version=verstr)
+    parser.add_argument('-v', '--verbose', action='count', default=1,
+                        help='Increase verbosity of status messages to '
+                             'display during workflow.')
+    parser.add_argument('-q', '--quiet', action='store_true', default=False,
+                        help='Suppress all status messages during workflow.')
+    parser.add_argument('--debug', action='store_true', help=SUPPRESS)
 
-    g_data = parser.add_argument_group('Options to specify what AHBA data to '
-                                       'use')
-    g_data.add_argument('--donors', action='store', nargs='+', default='all',
+    a_data = parser.add_argument_group('Options to specify information about '
+                                       'the atlas used')
+    a_data.add_argument('--atlas_info', '--atlas-info', action='store',
+                        type=_resolve_path, default=None, metavar='PATH',
+                        help='Filepath to CSV files containing information '
+                             'about `atlas`. The CSV file must have at least '
+                             'columns ["id", "hemisphere", "structure"] which'
+                             'contain information mapping the atlas IDs to '
+                             'hemispheres (i.e, "L", "R") and broad '
+                             'structural groups (i.e., "cortex", "subcortex", '
+                             '"cerebellum", "brainstem").')
+
+    g_data = parser.add_argument_group('Options to specify which AHBA data to '
+                                       'use during processing')
+    g_data.add_argument('--donors', action='store', nargs='+',
+                        default='all', metavar='DONOR_ID',
                         help='List of donors to use as sources of expression '
                              'data. Specified IDs can be either donor numbers '
                              '(i.e., 9861, 10021) or UIDs (i.e., H0351.2001). '
                              'If not specified all available donors will be '
                              'used.')
-    g_data.add_argument('--data-dir', '--data_dir', action='store', type=Path,
+    g_data.add_argument('--data_dir', '--data-dir', action='store',
+                        type=_resolve_path, metavar='PATH',
                         help='Directory where expression data should be '
                              'downloaded to (if it does not already exist) / '
                              'loaded from. If not specified this will check '
@@ -38,14 +113,171 @@ def get_parser():
                              'downloaded to the first of these location that '
                              'exists and for which write access is enabled.')
 
+    w_data = parser.add_argument_group('Options to specify processing options')
+    w_data.add_argument('--inexact', dest='exact', action='store_false',
+                        default=True,
+                        help='Whether to use inexact matching of donor tissue '
+                             'samples to parcels in `atlas`. By default, the '
+                             'workflow will match tissue samples to parcels '
+                             'within `tolerance` mm of the sample; any '
+                             'samples that are beyond `tolerance` mm of a '
+                             'parcel will be discarded, which may result in '
+                             'some parcels having no assigned sample / '
+                             'expression data. If --inexact, the matching'
+                             'procedure will be performed and followed by a '
+                             'check for parcels with no assigned samples; any '
+                             'such parcels will be matched to the nearest '
+                             'sample (nearest defined as the sample with the '
+                             'closest Euclidean distance to the parcel '
+                             'centroid).')
+    w_data.add_argument('--tol', '--tolerance', dest='tolerance',
+                        action='store', type=float, default=2,
+                        help='Distance (in mm) that a sample can be from a '
+                             'parcel for it to be matched to that parcel. '
+                             'This is only considered if the sample is not '
+                             'directly within a parcel. Default: 2')
+    w_data.add_argument('--ibf_threshold', '--ibf-threshold', action='store',
+                        default=0.5, metavar='THRESHOLD',
+                        help='Threshold for intensity-based filtering of '
+                             'probes. This number should specify the ratio of '
+                             'samples, across all supplied donors, for which '
+                             'a probe must have signal above background noise '
+                             'in order to be retained. Default: 0.5')
+    w_data.add_argument('--metric', action='store', default='mean',
+                        metavar='METHOD', choices=['mean', 'median'],
+                        help='Mechanism by which to (1) reduce expression '
+                             'data of multiple samples in the same `atlas` '
+                             'region, and (2) reduce donor-level expression '
+                             'data into a single "group" expression '
+                             'dataframe. Default: mean')
+    w_data.add_argument('--probe_selection', '--probe-selection',
+                        action='store', default='diff_stability',
+                        metavar='METHOD',
+                        choices=['average', 'mean', 'max_intensity',
+                                 'max_variance', 'pc_loading', 'corr_variance',
+                                 'corr_intensity', 'diff_stability'],
+                        help='Selection method for subsetting (or collapsing '
+                             'across) probes that index the same gene. Must '
+                             'be one of {average, mean, max_intensity, '
+                             'max_variance, pc_loading, corr_variance, '
+                             'corr_intensity, diff_stability}. Default: '
+                             'diff_stability')
+
+    p_data = parser.add_argument_group('Options to modify the AHBA data used')
+    p_data.add_argument('--no-reannotated', '--no_reannotated',
+                        dest='reannotated', action='store_false', default=True,
+                        help='Whether to use the default probe information'
+                             'from the AHBA dataset instead of the '
+                             'reannotated probe information from '
+                             'Arnatkevic̆iūtė et al., 2019. Using reannotated '
+                             'probe information (default) discards probes '
+                             'that could not be reliably matched to genes.')
+    p_data.add_argument('--no-corrected-mni', '--no_corrected_mni',
+                        dest='corrected_mni', action='store_false',
+                        default=True,
+                        help='Whether to use the original MNI coordinates '
+                             'provided with the AHBA data instead of the '
+                             '"corrected" MNI coordinates shipped with the '
+                             '`alleninf` package when matching tissue samples '
+                             'to anatomical regions.')
+
+    o_data = parser.add_argument_group('Options to modify how data is output')
+    o_data.add_argument('--stdout', action='store_true',
+                        help='Generated region x gene dataframes will be '
+                             'printed to stdout for piping to other things. '
+                             'You should REALLY consider just using --output-'
+                             'file instead and working with the generated '
+                             'CSV file(s). Incompatible with `--save-counts` '
+                             'and --save-donors.')
+    o_data.add_argument('--output-file', '--output_file', action='store',
+                        type=_resolve_path, metavar='PATH',
+                        default='abagen_expression.csv',
+                        help='Path to desired output file. The generated '
+                             'region x gene dataframe will be saved here.')
+    o_data.add_argument('--save-counts', '--save_counts', action='store_true',
+                        help='Whether to save dataframe containing number of '
+                             'samples from each donor that were assigned '
+                             'to each region in `atlas`. If specified, will '
+                             'be saved to the path specified by '
+                             '`output-file`, appending "counts" to the end of '
+                             'the filename.')
+    o_data.add_argument('--save-donors', '--save_donors', action='store_true',
+                        help='Whether to save donor-level expression '
+                             'dataframes instead of aggregating expression '
+                             'across donosr with provided `metric`. If '
+                             'specified, dataframes will be saved to path '
+                             'specified by `output-file`, appending donor IDs '
+                             'to the end of the filename.')
+
     return parser
 
 
 def main():
+    """ Runs primary get_expression_data workflow
+    """
+
+    from ..allen import get_expression_data
+    from ..datasets import WELL_KNOWN_IDS as donors
+
     opts = get_parser().parse_args()
 
-    expression = get_expression_data(**opts)
+    # quiet overrides any verbosity setting
+    if opts.quiet:
+        opts.verbose = 0
 
-    if opts.stdout:  # WHY?!
+    # debugging is fun
+    if opts.debug:
+        print(opts)
+        return
+
+    # run the workflow
+    expression = get_expression_data(atlas=str(opts.atlas),
+                                     atlas_info=opts.atlas_info,
+                                     exact=opts.exact,
+                                     tolerance=opts.tolerance,
+                                     metric=opts.metric,
+                                     ibf_threshold=opts.ibf_threshold,
+                                     probe_selection=opts.probe_selection,
+                                     corrected_mni=opts.corrected_mni,
+                                     reannotated=opts.reannotated,
+                                     return_counts=opts.save_counts,
+                                     return_donors=opts.save_donors,
+                                     donors=opts.donors,
+                                     data_dir=opts.data_dir,
+                                     verbose=opts.verbose)
+
+    output_path = os.path.dirname(opts.output_file)
+    fname_pref = os.path.splitext(os.path.basename(opts.output_file))[0]
+
+    # WHY?!?
+    if opts.stdout and not (opts.save_counts or opts.save_donors):
         expression.to_csv(sys.stdout)
         return
+
+    # expand the tuple, if needed
+    if opts.save_counts:
+        expression, counts = expression
+        counts_fname = os.path.join(output_path, fname_pref + '_counts.csv')
+        lgr.info('Saving samples counts to {}'.format(counts_fname))
+        counts.to_csv(counts_fname)
+
+    # determine how best to save expression output files
+    if opts.save_donors:
+        if opts.donors == 'all':
+            donors = list(donors.value_set('subj'))
+        else:
+            donors = [donors[f] for f in opts.donors]
+
+        # save each donor dataframe as a separate file
+        for donor, exp in zip(donors, expression):
+            exp_fname = os.path.join(output_path,
+                                     fname_pref + '_{}.csv'.format(donor))
+            lgr.info('Saving donor {} info to {}'.format(donor, exp_fname))
+            exp.to_csv(exp_fname)
+    else:
+        expression.to_csv(opts.output_file)
+
+
+if __name__ == '__main__':
+    raise RuntimeError('abagen/cli/run.py should not be run directly.\nPlease '
+                       '`pip install` abagen and use the `abagen` command.')

--- a/abagen/cli/run.py
+++ b/abagen/cli/run.py
@@ -14,7 +14,10 @@ def _resolve_path(path):
     """
 
     if path is not None:
-        return str(Path(path).expanduser().resolve())
+        try:
+            return str(Path(path).expanduser().resolve())
+        except FileNotFoundError:
+            return os.path.abspath(os.path.expanduser(path))
 
 
 class CheckExists(argparse.Action):

--- a/abagen/cli/run.py
+++ b/abagen/cli/run.py
@@ -37,7 +37,7 @@ def get_parser():
 
     from .. import __version__
 
-    verstr = 'abagen v{}'.format(__version__)
+    verstr = 'abagen {}'.format(__version__)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""

--- a/abagen/cli/run.py
+++ b/abagen/cli/run.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from argparse import ArgumentParser
+from pathlib import Path
+import sys
+
+from ..allen import get_expression_data
+
+
+def get_parser():
+    from ..info import __version__
+
+    verstr = 'abagen v{}'.format(__version__)
+    parser = ArgumentParser(description='')
+
+    parser.add_argument('atlas', action='store', type=Path,
+                        help='An image in MNI space, where each parcel in the'
+                             'image is identified by a unique integer ID.')
+
+    parser.add_argument('--version', action='version', version=verstr)
+
+    g_data = parser.add_argument_group('Options to specify what AHBA data to '
+                                       'use')
+    g_data.add_argument('--donors', action='store', nargs='+', default='all',
+                        help='List of donors to use as sources of expression '
+                             'data. Specified IDs can be either donor numbers '
+                             '(i.e., 9861, 10021) or UIDs (i.e., H0351.2001). '
+                             'If not specified all available donors will be '
+                             'used.')
+    g_data.add_argument('--data-dir', '--data_dir', action='store', type=Path,
+                        help='Directory where expression data should be '
+                             'downloaded to (if it does not already exist) / '
+                             'loaded from. If not specified this will check '
+                             'the environmental variable ABAGEN_DATA, the '
+                             '$HOME/abagen-data directory, and the current '
+                             'working directory. If data does not already '
+                             'exist at one of those locations then it will be '
+                             'downloaded to the first of these location that '
+                             'exists and for which write access is enabled.')
+
+    return parser
+
+
+def main():
+    opts = get_parser().parse_args()
+
+    expression = get_expression_data(**opts)
+
+    if opts.stdout:  # WHY?!
+        expression.to_csv(sys.stdout)
+        return

--- a/abagen/tests/conftest.py
+++ b/abagen/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from abagen.datasets import fetch_microarray
+from abagen.datasets import fetch_desikan_killiany, fetch_microarray
 
 
 @pytest.fixture(scope='session')
@@ -14,3 +14,8 @@ def testfiles(testdir):
                              donors=['12876', '15496'],
                              convert=True)
     return files
+
+
+@pytest.fixture(scope='session')
+def atlas():
+    return fetch_desikan_killiany()

--- a/abagen/tests/test_cli.py
+++ b/abagen/tests/test_cli.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for abagen.cli module
+"""
+
+import os
+import pytest
+
+from abagen.cli import run
+
+
+def test_run_get_parser(atlas, testdir):
+    parser = run.get_parser()
+
+    # since we have a positional argument this fails, hard
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+    # providing a valid arg succeeds though!
+    args = parser.parse_args([atlas['image']])
+    assert args.atlas == atlas['image']
+
+    # providing an invalid arg fails again
+    with pytest.raises(SystemExit):
+        parser.parse_args(['notanatlas.nii.gz'])
+
+
+def test_run_main(atlas, testdir):
+    run.main([
+        '--data-dir', testdir,
+        '--donors', '12876', '15496',
+        '--output-file', os.path.join(str(testdir), 'abagen_expression.csv'),
+        atlas['image']
+    ])
+
+    assert os.path.exists(os.path.join(str(testdir), 'abagen_expression.csv'))

--- a/abagen/tests/test_cli.py
+++ b/abagen/tests/test_cli.py
@@ -7,23 +7,61 @@ import os
 from pkg_resources import resource_filename
 import pytest
 
+from abagen import __version__ as version
 from abagen.cli import run
 
 
-def test_run_get_parser(atlas, testdir):
+def test_run_get_parser(capsys, atlas, testdir):
     parser = run.get_parser()
 
     # since we have a positional argument this fails, hard
     with pytest.raises(SystemExit):
         parser.parse_args([])
+    assert "following arguments are required: atlas" in capsys.readouterr().err
 
-    # providing a valid arg succeeds though!
+    # providing the positional succeeds!
     args = parser.parse_args([atlas['image']])
     assert args.atlas == atlas['image']
 
-    # providing an invalid arg fails again
+    # some data directories/files need to exist!
     with pytest.raises(SystemExit):
         parser.parse_args(['notanatlas.nii.gz'])
+    assert "does not exist" in capsys.readouterr().err
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--data-dir', 'notadir', atlas['image']])
+    assert "does not exist" in capsys.readouterr().err
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--atlas-info', 'notafile', atlas['image']])
+    assert "does not exist" in capsys.readouterr().err
+
+    # does version print correctly?
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--version'])
+    assert 'abagen {}'.format(version) == capsys.readouterr().out.strip()
+
+    # arguments with invalid choices (probe_selection) raise errors
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--probe-selection', 'notamethod', atlas['image']])
+    assert "invalid choice: 'notamethod'" in capsys.readouterr().err
+
+    # just test every option
+    args = parser.parse_args([
+        '-v', '-v', '-v',
+        '--quiet',
+        '--debug',
+        '--atlas-info', atlas['info'],
+        '--donors', '12876', '15496',
+        '--data-dir', testdir,
+        '--inexact',
+        '--tol', '5',
+        '--ibf-threshold', '0.6',
+        '--metric', 'median',
+        '--probe-selection', 'average',
+        '--no-reannotated', '--no-corrected-mni',
+        '--output-file', 'test.csv',
+        '--save-counts', '--save-donors',
+        atlas['image']
+    ])
 
 
 def test_run_main(capsys, atlas, testdir):

--- a/abagen/tests/test_cli.py
+++ b/abagen/tests/test_cli.py
@@ -4,6 +4,7 @@ Tests for abagen.cli module
 """
 
 import os
+from pkg_resources import resource_filename
 import pytest
 
 from abagen.cli import run
@@ -25,12 +26,47 @@ def test_run_get_parser(atlas, testdir):
         parser.parse_args(['notanatlas.nii.gz'])
 
 
-def test_run_main(atlas, testdir):
+def test_run_main(capsys, atlas, testdir):
+    outputfile = os.path.join(str(testdir), 'abagen_expression.csv')
+
+    # check basic usage
     run.main([
         '--data-dir', testdir,
         '--donors', '12876', '15496',
-        '--output-file', os.path.join(str(testdir), 'abagen_expression.csv'),
+        '--output-file', outputfile,
         atlas['image']
     ])
+    assert os.path.exists(outputfile)
 
-    assert os.path.exists(os.path.join(str(testdir), 'abagen_expression.csv'))
+    # check that save donors/counts outputs desired files
+    run.main([
+        '--data-dir', testdir,
+        '--donors', '12876', '15496',
+        '--output-file', outputfile,
+        '--save-donors', '--save-counts',
+        atlas['image']
+    ])
+    for rep in ['_counts.csv', '_12876.csv', '_15496.csv']:
+        assert os.path.exists(outputfile.replace('.csv', rep))
+
+    # check stdout (BLARGH)
+    run.main([
+        '--data-dir', testdir,
+        '--donors', '12876', '15496',
+        '--output-file', outputfile,
+        '--stdout',
+        atlas['image']
+    ])
+    stdout = capsys.readouterr().out
+    with open(outputfile, 'r') as src:
+        assert stdout == src.read()
+
+
+def test_exec_run_fail():
+    executable = resource_filename('abagen', 'cli/run.py')
+
+    # need to set this otherwise it won't fail
+    __name__ = '__main__'  # noqa
+    with pytest.raises(RuntimeError):
+        with open(executable, 'r') as src:
+            exec(src.read())

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,18 @@
+.. _cli:
+
+------------------
+Command-line usage
+------------------
+
+You can use many of the primary workflows in ``abagen`` from the command line.
+
+.. _cli_abagen:
+
+The ``abagen`` command
+======================
+
+.. argparse::
+   :ref: abagen.cli.run.get_parser
+   :prog: abagen
+   :nodefault:
+   :nodefaultconst:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
+    'sphinxarg.ext',
 ]
 
 # Generate the API documentation when building

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,5 +8,6 @@ Contents
 
    installation
    changes
+   cli
    usage
    api

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 -r ../requirements.txt
-sphinx>=1.2
+sphinx>=1.6
+sphinx-argparse
 sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,8 @@ include_package_data = True
 
 [options.extras_require]
 doc =
-    sphinx >=1.2
+    sphinx >=1.6
+    sphinx-argparse
     sphinx_rtd_theme
 io =
     fastparquet
@@ -53,6 +54,10 @@ all =
 nibabel =
     tests/data/*
     abagen/data/*
+
+[options.entry_points]
+console_scripts =
+    abagen=abagen.cli.run:main
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Closes #70 

Adds a command-line interface for the primary workflow available through the `abagen.get_expression_data()` function so that users don't have to open a Python instance if they're more comfortable with shell scripting.

To do:
- [ ] Add comprehensive tests for CLI
- [x] Clean up documentation addressing CLI usage