### PR TITLE
[FIX] Fixes broken include directive in API reference

### DIFF
--- a/abagen/datasets/__init__.py
+++ b/abagen/datasets/__init__.py
@@ -1,3 +1,8 @@
+"""
+Functions for fetching data relevant to the Allen Brain Atlas human microarray
+dataset
+"""
+
 __all__ = [
     'fetch_microarray', 'fetch_raw_mri', 'fetch_desikan_killiany',
     'fetch_gene_group', 'WELL_KNOWN_IDS', '_get_dataset_dir'

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,9 +10,9 @@ Reference API
 
 .. _ref_workflows:
 
-:mod:`abagen` - Primary workflows
----------------------------------
-.. automodule:: abagen
+:mod:`abagen.allen` - Primary workflows
+---------------------------------------
+.. automodule:: abagen.allen
    :no-members:
    :no-inherited-members:
 
@@ -32,14 +32,16 @@ Reference API
    :no-members:
    :no-inherited-members:
 
-.. currentmodule:: abagen.datasets
+.. currentmodule:: abagen
 
 .. autosummary::
    :template: function.rst
    :toctree: generated/
 
-   abagen.datasets.fetch_microarray
-   abagen.datasets.fetch_desikan_killiany
+   abagen.fetch_microarray
+   abagen.fetch_raw_mri
+   abagen.fetch_desikan_killiany
+   abagen.fetch_gene_group
 
 .. _ref_io:
 
@@ -67,14 +69,14 @@ Reference API
    :no-members:
    :no-inherited-members:
 
-.. currentmodule:: abagen.correct
+.. currentmodule:: abagen
 
 .. autosummary::
    :template: function.rst
    :toctree: generated/
 
-   abagen.correct.remove_distance
-   abagen.correct.keep_stable_genes
+   abagen.remove_distance
+   abagen.keep_stable_genes
 
 :mod:`abagen.utils` - Utility functions
 ---------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -r ../requirements.txt
-sphinx>=1.6
+sphinx>=2.0
 sphinx-argparse
 sphinx_rtd_theme


### PR DESCRIPTION
For some reason the use of the `.. include` directive in the index.rst of the docs is breaking the API section of the docs (basically, the entirety of the README is duplicated in the API). This resolves that issue and makes a few minor aesthetic updates to the API.

Additionally, ReadTheDocs is using sphinx version 1.8.1 (or something similar) which is rendering the CLI argument tables weirdly. This pins the Sphinx version to >=2.0.