### PR TITLE
[FIX] Installation not correctly bundling package data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ dist: xenial
 notifications:
   email: change
 
+branches:
+  only:
+    - master
+
 python:
   - 3.5
   - 3.6
@@ -70,7 +74,10 @@ script:
       make html;
       travis_wait 40 make doctest;
     elif [ "${CHECK_TYPE}" == "test" ]; then
-      travis_wait 40 python -m pytest --cov-report term-missing --cov=abagen --doctest-modules abagen;
+      mkdir for_testing && cd for_testing;
+      cp ../setup.cfg .;
+      args="--cov-report term-missing --cov=abagen --doctest-modules --pyargs";
+      travis_wait 40 python -m pytest ${args} ${rootdir} abagen;
     else
       false;
     fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.* LICENSE setup* MANIFEST.in CHANGELOG requirements.txt
+recursive-include abagen/data *
+recursive-include abagen/tests/data *
 include versioneer.py
 include abagen/_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,9 @@ all =
     %(test)s
 
 [options.package_data]
-nibabel =
-    tests/data/*
+abagen =
     abagen/data/*
+    abagen/tests/data/*
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Wasn't bundling package data for certain installation types. Partly due to typos in the `setup.cfg`, partly due to a missing recursive-include in the MANIFEST.in.

Also modify travis tests so they don't happen inside the repository directory, which I think was hiding these issues.