### PR TITLE
[REF] Fixes one-donor bug in get_expression_data()

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -307,15 +307,16 @@ def get_expression_data(atlas, atlas_info=None, *, exact=True,
     # fetch files (downloading if necessary) and unpack to variables
     files = datasets.fetch_microarray(data_dir=data_dir, donors=donors,
                                       verbose=verbose)
-    for key in ['microarray', 'probes', 'annotation', 'pacall', 'ontology']:
-        if key not in files:
-            raise KeyError('Provided `files` dictionary is missing {}. '
-                           'Please check inputs.'.format(key))
     microarray = files['microarray']
     annotation = files['annotation']
     pacall = files['pacall']
     ontology = files['ontology']
     probe_info = files['probes'][0]
+
+    if probe_selection == 'diff_stability' and len(microarray) == 1:
+        raise ValueError('Cannot use diff_stability for probe_selection with '
+                         'only one donor. Please specify a different probe_'
+                         'selection method or use more donors.')
 
     # get some info on labels in `atlas_img`
     all_labels = utils.get_unique_labels(atlas)

--- a/abagen/tests/test_allen.py
+++ b/abagen/tests/test_allen.py
@@ -34,6 +34,18 @@ def test_extra_get_expression_data(testfiles, atlas, opts):
     assert out.columns.name == 'gene_symbol'
 
 
+def test_get_expression_data_errors(testfiles, atlas):
+    # invalid probe_selection method
+    with pytest.raises(ValueError):
+        allen.get_expression_data(atlas['image'], donors=['12876', '15496'],
+                                  probe_selection='nonsense')
+
+    # cannot use diff_stability with only one donor
+    with pytest.raises(ValueError):
+        allen.get_expression_data(atlas['image'], donors=['12876'],
+                                  probe_selection='diff_stability')
+
+
 def test_missing_labels(testfiles, atlas):
     # remove some labels from atlas image so numbers are non-sequential
     remove = [10, 20, 60]


### PR DESCRIPTION
Closes #5 

When supplying only one donor via the `donor` parameter to `abagen.get_expression_data()` and using the default `probe_selection` method ('diff_stability') a really cryptic error was raised. This catches that specific combination and raises a more helpful error.

Also adds tests for the errors raised by `abagen.get_expression_data()`.