### PR TITLE
[FIX] specify engine='python' in pandas queries

### DIFF
--- a/abagen/samples.py
+++ b/abagen/samples.py
@@ -178,7 +178,8 @@ def drop_mismatch_samples(annotation, ontology):
     annot = annot.assign(hemisphere=hemisphere, structure=structure) \
                  .query('(hemisphere == "L" & mni_x < 0) '
                         '| (hemisphere == "R" & mni_x > 0) '
-                        '| (hemisphere.isna() & mni_x == 0)')
+                        '| (hemisphere.isna() & mni_x == 0)',
+                        engine='python')
 
     return annot
 


### PR DESCRIPTION
Closes #116.

Specify engine='python' in pandas query in drop_mismatch
function (in samples.py file) since engine='numexpr' cannot
handle NaNs and the later is the default option.