### PR TITLE
[REF] Removes `.get_data()` nibabel calls

### DIFF
--- a/abagen/samples.py
+++ b/abagen/samples.py
@@ -215,7 +215,7 @@ def _assign_sample(sample, atlas, sample_info=None, atlas_info=None,
     """
 
     # pull relevant info from atlas
-    label_data = utils.check_img(atlas).get_data()
+    label_data = np.asarray(utils.check_img(atlas).dataobj)
 
     # expand provided coordinates to include those w/i `tolerance` of `coords`
     # set a hard euclidean distance limit to account for different voxel sizes
@@ -337,7 +337,7 @@ def label_samples(annotation, atlas, atlas_info=None, tolerance=2):
     # get annotation and atlas data
     annotation = io.read_annotation(annotation)
     atlas = utils.check_img(atlas)
-    label_data, affine = atlas.get_data(), atlas.affine
+    label_data, affine = np.asarray(atlas.dataobj), atlas.affine
 
     # load atlas_info, if provided
     if atlas_info is not None:

--- a/abagen/tests/test_allen.py
+++ b/abagen/tests/test_allen.py
@@ -52,7 +52,7 @@ def test_missing_labels(testfiles, atlas):
 
     # subset atlas image
     img = check_img(atlas['image'])
-    img_data = img.get_data()
+    img_data = np.asarray(img.dataobj)
     for i in remove:
         img_data[img_data == i] = 0
     img = img.__class__(img_data, img.affine)

--- a/abagen/utils.py
+++ b/abagen/utils.py
@@ -38,20 +38,20 @@ def check_img(img):
 
     # ensure 3D or squeezable to 3D (this is a faster check than type casting)
     if len(img.shape) == 4 and img.shape[3] == 1:
-        data = img.get_data()
+        data = np.asarray(img.dataobj)
         affine = img.affine
         img = img.__class__(data[:, :, :, 0], affine, header=img.header)
     elif len(img.shape) != 3:
         raise ValueError('Provided image must be 3D')
 
     # check if atlas is int or castable to int
-    if img.get_data().dtype.kind != 'i':
-        cast = all([float(f).is_integer() for f in np.unique(img.get_data())])
+    if np.asarray(img.dataobj).dtype.kind != 'i':
+        cast = all([float(f).is_integer() for f in np.unique(img.dataobj)])
         if not cast:
             raise ValueError('Provided image should have integer values or '
                              'be safely castable to integer')
-        img = img.__class__(img.get_data().astype(np.int32), img.affine,
-                            header=img.header)
+        img = img.__class__(np.asarray(img.dataobj).astype(np.int32),
+                            img.affine, header=img.header)
         img.header.set_data_dtype(np.int32)
 
     return img
@@ -220,7 +220,7 @@ def get_unique_labels(label_image):
     """
 
     label_image = check_img(label_image)
-    return np.trim_zeros(np.unique(label_image.get_data())).astype(int)
+    return np.trim_zeros(np.unique(label_image.dataobj)).astype(int)
 
 
 def get_centroids(image, labels=None, image_space=False):
@@ -245,7 +245,7 @@ def get_centroids(image, labels=None, image_space=False):
     """
 
     image = check_img(image)
-    data = image.get_data()
+    data = np.asarray(image.dataobj)
 
     # if no labels of interest provided, get all possible labels
     if labels is None:


### PR DESCRIPTION
Deprecated as of 3.0 in favor of `np.asarray(img.dataobj)`.