### PR TITLE
[FIX,ENH] Error in get_expression_data, gene stability calculation

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -331,7 +331,7 @@ def get_expression_data(atlas, atlas_info=None, *,
                           index=np.append([0], all_labels))
     for subj in range(len(microarray)):
         if lr_mirror:  # reset index (duplicates will cause issues if we don't)
-            # TODO: come up
+            # TODO: come up with alternative sample IDs for mirrored samples
             annotation[subj] = annotation[subj].reset_index(drop=True)
             microarray[subj] = microarray[subj].reset_index(drop=True)
 
@@ -368,6 +368,8 @@ def get_expression_data(atlas, atlas_info=None, *,
             idx, dist = utils.closest_centroid(annotation[subj][cols],
                                                centroids[empty],
                                                return_dist=True)
+            if not hasattr(idx, '__len__'):  # TODO: better way to check this?
+                idx, dist = np.array([idx]), np.array([dist])
             idx = microarray[subj].loc[annotation[subj].iloc[idx].index]
             empty = all_labels[empty]
             idx.index = pd.Series(empty, name='label')

--- a/abagen/correct.py
+++ b/abagen/correct.py
@@ -527,7 +527,8 @@ def _resid_dist(dv, iv):
     return residuals.squeeze()
 
 
-def keep_stable_genes(expression, threshold=0.9, percentile=True, rank=True):
+def keep_stable_genes(expression, threshold=0.9, percentile=True, rank=True,
+                      return_stability=False):
     """
     Removes genes in `expression` with differential stability < `threshold`
 
@@ -552,12 +553,18 @@ def keep_stable_genes(expression, threshold=0.9, percentile=True, rank=True):
     rank : bool, optional
         Whether to calculate similarity as Spearman correlation instead of
         Pearson correlation. Default: True
+    return_stability : bool, optional
+        Whether to return stability estimates for each gene in addition to
+        expression data. Default: False
 
     Returns
     -------
     expression : list of (R, Gr) pandas.DataFrame
         Microarray expression for `R` regions across `Gr` genes, where `Gr` is
         the number of retained genes
+    stability : (G,) numpy.ndarray
+        Stability (average correlation) of each gene across pairs of donors.
+        Only returned if ``return_stability=True``
     """
 
     # get number of donors and number of genes
@@ -584,7 +591,10 @@ def keep_stable_genes(expression, threshold=0.9, percentile=True, rank=True):
     # calculate absolute threshold if percentile is desired
     if percentile:
         threshold = np.percentile(gene_corrs, threshold * 100)
-    keep_genes = gene_corrs > threshold
+    keep_genes = gene_corrs >= threshold
     expression = [e.iloc[:, keep_genes] for e in expression]
+
+    if return_stability:
+        return expression, gene_corrs
 
     return expression

--- a/abagen/tests/test_correct.py
+++ b/abagen/tests/test_correct.py
@@ -209,3 +209,9 @@ def test_keep_stable_genes(donor_expression):
         assert all([isinstance(f, pd.DataFrame) for f in out])
         for df1, df2 in itertools.combinations(out, 2):
             assert df1.shape == df2.shape
+
+    # check that `return_stability` provides expression and stability
+    out, stab = correct.keep_stable_genes(donor_expression, threshold=0,
+                                          return_stability=True)
+    assert len(stab) == len(out[0].columns)
+    assert np.all(out[0].columns == donor_expression[0].columns)


### PR DESCRIPTION
Fixes an error in `get_expression_data()` when `exact=False` and there was only one ROI missing expression data.

Also adds an option to be able to get gene stability estimates.