### PR TITLE
[ENH] Adds fetchers / loaders for RNAseq data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - persist_to_workspace:
           root: /tmp
           paths:
-              - src/data/allenbrain
+              - src/data/microarray
   style_check:
     executor: conda_exec
     steps:

--- a/abagen/__init__.py
+++ b/abagen/__init__.py
@@ -2,7 +2,7 @@ __all__ = [
     '__version__', '__doc__',
     'io', 'mouse', 'get_expression_data', 'keep_stable_genes',
     'normalize_expression', 'remove_distance', 'fetch_desikan_killiany',
-    'fetch_gene_group', 'fetch_microarray', 'fetch_raw_mri'
+    'fetch_gene_group', 'fetch_microarray', 'fetch_raw_mri', 'fetch_rnaseq'
 ]
 
 from ._version import get_versions
@@ -15,4 +15,4 @@ from . import io, mouse
 from .allen import get_expression_data
 from .correct import keep_stable_genes, normalize_expression, remove_distance
 from .datasets import (fetch_desikan_killiany, fetch_gene_group,
-                       fetch_microarray, fetch_raw_mri)
+                       fetch_microarray, fetch_raw_mri, fetch_rnaseq)

--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -153,7 +153,9 @@ def get_expression_data(atlas, atlas_info=None, *,
     donors : list, optional
         List of donors to use as sources of expression data. Can be either
         donor numbers or UID. If not specified will use all available donors.
-        Default: 'all'
+        Note that donors '9861' and '10021' have samples from both left + right
+        hemispheres; all other donors have samples from the left hemisphere
+        only. Default: 'all'
     data_dir : str, optional
         Directory where expression data should be downloaded (if it does not
         already exist) / loaded. If not specified will use the current
@@ -172,12 +174,12 @@ def get_expression_data(atlas, atlas_info=None, *,
         Microarray expression for `R` regions in `atlas` for `G` genes,
         aggregated across donors, where the index corresponds to the unique
         integer IDs of `atlas` and the columns are gene names. If
-        ``return_donors`` is set to ``True`` then this is a list of (R, G)
-        dataframes, one for each donor.
+        ``return_donors=True`` then this is a list of (R, G) dataframes, one
+        for each donor.
     counts : (R, D) pandas.DataFrame
         Number of samples assigned to each of `R` regions in `atlas` for each
         of `D` donors (if multiple donors were specified); only returned if
-        ``return_counts`` is set to ``True``.
+        ``return_counts=True``.
 
     Notes
     -----
@@ -285,6 +287,9 @@ def get_expression_data(atlas, atlas_info=None, *,
         raise ValueError('Cannot use diff_stability for probe_selection with '
                          'only one donor. Please specify a different probe_'
                          'selection method or use more donors.')
+    elif probe_selection == 'rnaseq':  # fetch RNAseq if we're gonna need it
+        datasets.fetch_rnaseq(data_dir=data_dir, donors=donors,
+                              verbose=verbose)
 
     # get some info on labels in `atlas_img`
     all_labels = utils.get_unique_labels(atlas)

--- a/abagen/datasets/__init__.py
+++ b/abagen/datasets/__init__.py
@@ -5,9 +5,9 @@ dataset
 
 __all__ = [
     'fetch_microarray', 'fetch_raw_mri', 'fetch_desikan_killiany',
-    'fetch_gene_group', 'WELL_KNOWN_IDS', '_get_dataset_dir'
+    'fetch_gene_group', 'fetch_rnaseq', 'WELL_KNOWN_IDS', '_get_dataset_dir'
 ]
 
 from .fetchers import (fetch_microarray, fetch_raw_mri, fetch_desikan_killiany,
-                       fetch_gene_group, WELL_KNOWN_IDS)
+                       fetch_gene_group, fetch_rnaseq, WELL_KNOWN_IDS)
 from .utils import _get_dataset_dir

--- a/abagen/datasets/fetchers.py
+++ b/abagen/datasets/fetchers.py
@@ -272,7 +272,7 @@ def check_donors(donors, default='12876', valid=VALID_DONORS):
             raise ValueError('Invalid subject id: {0}. Subjects must in: {1}.'
                              .format(sub_id, valid))
         donors[n] = WELL_KNOWN_IDS[sub_id]  # convert to ID system
-    donors = sorted(set(donors), key=lambda x: donors.index(x))
+    donors = sorted(set(donors), key=lambda x: int(x))
 
     return donors
 

--- a/abagen/datasets/fetchers.py
+++ b/abagen/datasets/fetchers.py
@@ -67,7 +67,7 @@ def fetch_microarray(data_dir=None, donors=None, resume=True, verbose=1,
 
     url = "https://human.brain-map.org/api/v2/well_known_file_download/{}"
 
-    dataset_name = 'allenbrain'
+    dataset_name = 'microarray'
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
 
@@ -162,7 +162,7 @@ def fetch_rnaseq(data_dir=None, donors=None, resume=True, verbose=1):
     sub_files = ('Contents.txt', 'Genes.csv', 'Ontology.csv',
                  'RNAseqCounts.csv', 'RNAseqTPM.csv', 'SampleAnnot.csv')
     n_files = len(sub_files)
-    valid = ['9861', '10021', 'H00351.2001', 'H00351.2002']
+    valid = ['9861', '10021', 'H0351.2001', 'H0351.2002']
     donors = check_donors(donors, default=valid[0], valid=valid)
 
     files = [
@@ -213,7 +213,7 @@ def fetch_raw_mri(data_dir=None, donors=None, resume=True, verbose=1):
 
     url = "https://human.brain-map.org/api/v2/well_known_file_download/{}"
 
-    dataset_name = 'allenbrain'
+    dataset_name = 'mri'
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
 
@@ -222,9 +222,9 @@ def fetch_raw_mri(data_dir=None, donors=None, resume=True, verbose=1):
     donors = check_donors(donors)
 
     files = [
-        (os.path.join('normalized_microarray_donor{}'.format(sub), fname),
+        (os.path.join('mri_donor{}'.format(sub), fname),
          url.format(getattr(WELL_KNOWN_IDS, img)[sub]),
-         dict(move=os.path.join('normalized_microarray_donor{}'.format(sub),
+         dict(move=os.path.join('mri_donor{}'.format(sub),
                                 fname)))
         for sub in donors
         for img, fname in sub_files.items()
@@ -262,10 +262,11 @@ def check_donors(donors, default='12876', valid=VALID_DONORS):
     if donors is None:
         donors = [default]
     elif donors == 'all':
-        donors = list(WELL_KNOWN_IDS.value_set('subj'))
+        donors = valid
     elif isinstance(donors, str):
         donors = [donors]
 
+    donors = list(donors)
     for n, sub_id in enumerate(donors):
         if sub_id not in valid:
             raise ValueError('Invalid subject id: {0}. Subjects must in: {1}.'

--- a/abagen/tests/conftest.py
+++ b/abagen/tests/conftest.py
@@ -6,7 +6,9 @@ Fixtures for all abagen tests
 import os
 import pytest
 
-from abagen.datasets import fetch_desikan_killiany, fetch_microarray
+from abagen.datasets import (fetch_desikan_killiany,
+                             fetch_microarray,
+                             fetch_rnaseq)
 
 
 @pytest.fixture(scope='session')
@@ -21,6 +23,11 @@ def datadir(tmp_path_factory):
 def testfiles(datadir):
     return fetch_microarray(data_dir=datadir, donors=['12876', '15496'],
                             n_proc=2)
+
+
+@pytest.fixture(scope='session')
+def rnafiles(datadir):
+    return fetch_rnaseq(data_dir=datadir, donors=['9861'])
 
 
 @pytest.fixture(scope='session')

--- a/abagen/tests/datasets/test_fetchers.py
+++ b/abagen/tests/datasets/test_fetchers.py
@@ -52,6 +52,23 @@ def test_fetch_raw_mri():
         fetchers.fetch_raw_mri(donors=['notadonor'])
 
 
+def test_fetch_rnaseq():
+    f1 = fetchers.fetch_rnaseq(donors=['9861'])
+    f2 = fetchers.fetch_rnaseq(donors='9861')
+    f3 = fetchers.fetch_rnaseq(donors='H0351.2001')
+    f4 = fetchers.fetch_rnaseq(donors=None)
+
+    assert f1 == f2 == f3 == f4
+    for k in ['genes', 'ontology', 'counts', 'tpm', 'annotation']:
+        assert len(f1.get(k)) == 1
+
+    with pytest.raises(ValueError):
+        fetchers.fetch_rnaseq(donors='notadonor')
+
+    with pytest.raises(ValueError):
+        fetchers.fetch_rnaseq(donors=['9861', 'notadonor'])
+
+
 @pytest.mark.parametrize('group, expected', [
     ('brain', 2413),
     ('neuron', 2530),

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,6 +63,8 @@ Reference API
    abagen.io.read_pacall
    abagen.io.read_probes
 
+.. _ref_correct:
+
 :mod:`abagen.correct` - Post-processing corrections
 ---------------------------------------------------
 .. automodule:: abagen.correct
@@ -79,38 +81,7 @@ Reference API
    abagen.keep_stable_genes
    abagen.normalize_expression
 
-:mod:`abagen.probes` - Operations on microarry probes
------------------------------------------------------
-.. automodule:: abagen.probes
-   :no-members:
-   :no-inherited-members:
-
-.. currentmodule:: abagen.probes
-
-.. autosummary::
-   :template: function.rst
-   :toctree: generated/
-
-   abagen.probes.reannotate_probes
-   abagen.probes.filter_probes
-   abagen.probes.collapse_probes
-
-:mod:`abagen.samples` - Operations on microarray samples
---------------------------------------------------------
-.. automodule:: abagen.samples
-   :no-members:
-   :no-inherited-members:
-
-.. currentmodule:: abagen.samples
-
-.. autosummary::
-   :template: function.rst
-   :toctree: generated/
-
-   abagen.samples.update_mni_coords
-   abagen.samples.drop_mismatch_samples
-   abagen.samples.label_samples
-   abagen.samples.mirror_samples
+.. _ref_utils:
 
 :mod:`abagen.utils` - Utility functions
 ---------------------------------------


### PR DESCRIPTION
Closes #98 

Adds new functions for fetching and loading RNAseq data. Modifies other related functions / updates some doc-strings as necessary (e.g., `io.read_annotation` doc-string).

The changes to `abagen.get_expression_data()` (i.e., the call to `fetch_rnaseq`) should never actually be trigged, currently, until #137 is addressed (we explicitly check the provided `probe_selection` method against `probes_.SELECTION_METHODS`, and since 'rnaseq' isn't a valid option it will error out before hitting the fetcher).