### PR TITLE
[MNT] Pin minimum pandas version to 0.25

### DIFF
--- a/abagen/datasets/fetchers.py
+++ b/abagen/datasets/fetchers.py
@@ -136,10 +136,10 @@ def fetch_microarray(data_dir=None, donors=None, resume=True, verbose=1,
                                         dict(resume=resume, verbose=verbose))
                        for f in files]
             # flatten outputs into single list
-            files = [l for res in results for l in res.get()]
+            files = [fn for res in results for fn in res.get()]
     else:
         # flatten list of lists into single list
-        files = [l for f in files for l in f]
+        files = [fn for f in files for fn in f]
         files = _fetch_files(data_dir, files, resume=resume, verbose=verbose)
 
     # if we want to convert files to parquet format it's good to do that now
@@ -213,7 +213,7 @@ def fetch_rnaseq(data_dir=None, donors=None, resume=True, verbose=1):
         for sub in donors
     ]
 
-    files = [l for f in files for l in f]
+    files = [fn for f in files for fn in f]
     files = _fetch_files(data_dir, files, resume=resume, verbose=verbose)
 
     keys = ['genes', 'ontology', 'counts', 'tpm', 'annotation']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 nibabel
 numpy>=1.14.0
-pandas
+pandas>=0.25.0
 scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.6
 install_requires =
     nibabel
     numpy >=1.14
-    pandas
+    pandas >=0.25.0
     scipy
 zip_safe = False
 packages = find:


### PR DESCRIPTION
Based on #150.

The `errors` kwarg for `pandas.DataFrame.rename` was only introduced in pandas v0.25.