### PR TITLE
[ENH] Allows users to get microarray samples in mask

### DIFF
--- a/abagen/__init__.py
+++ b/abagen/__init__.py
@@ -1,9 +1,9 @@
 __all__ = [
     '__version__', '__doc__',
-    'io', 'mouse', 'get_expression_data', 'keep_stable_genes',
-    'normalize_expression', 'remove_distance', 'fetch_desikan_killiany',
-    'fetch_gene_group', 'fetch_microarray', 'fetch_raw_mri', 'fetch_rnaseq',
-    'fetch_freesurfer'
+    'io', 'mouse', 'get_expression_data', 'get_samples_in_mask'
+    'keep_stable_genes', 'normalize_expression', 'remove_distance',
+    'fetch_desikan_killiany', 'fetch_gene_group', 'fetch_microarray',
+    'fetch_raw_mri', 'fetch_rnaseq', 'fetch_freesurfer'
 ]
 
 from ._version import get_versions
@@ -13,7 +13,7 @@ del get_versions
 from .info import long_description as __doc__
 
 from . import io, mouse
-from .allen import get_expression_data
+from .allen import get_expression_data, get_samples_in_mask
 from .correct import keep_stable_genes, normalize_expression, remove_distance
 from .datasets import (fetch_desikan_killiany, fetch_gene_group,
                        fetch_microarray, fetch_raw_mri, fetch_rnaseq,

--- a/abagen/correct.py
+++ b/abagen/correct.py
@@ -403,7 +403,7 @@ def normalize_expression(expression, norm='srs', ignore_warn=False):
         notna = np.logical_not(exp.isna().all(axis=1))
         data = np.asarray(exp)[notna]
 
-        kwargs = dict(divide='ignore', invalid='ignore') if ignore_warn else {}
+        kwargs = dict(all='ignore') if ignore_warn else {}
         with np.errstate(**kwargs):
             # normalize the data (however was specified)
             normed = normfunc(data) if norm != 'batch' else corrected[n]

--- a/abagen/tests/test_allen.py
+++ b/abagen/tests/test_allen.py
@@ -71,3 +71,19 @@ def test_missing_labels(testfiles, atlas):
 
     assert isinstance(counts, pd.DataFrame)
     assert counts.shape == (len(info), len(testfiles))
+
+
+def test_get_samples_in_mask(testfiles, atlas):
+    allexp, allcoords = allen.get_samples_in_mask(donors=['12876', '15496'])
+    cortexp, cortcoords = allen.get_samples_in_mask(mask=atlas['image'],
+                                                    donors=['12876', '15496'])
+
+    # exp + coords shape as expected?
+    assert len(allexp) == len(allcoords) and len(cortexp) == len(cortcoords)
+    assert allcoords.shape[-1] == 3 and cortcoords.shape[-1] == 3
+    for df in [allexp, cortexp]:
+        assert df.index.name == 'well_id'
+        assert df.columns.name == 'gene_symbol'
+
+    # providing the cortical mask (atlas) should reduce # of samples returned
+    assert len(allexp) > len(cortexp)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,6 +23,7 @@ Reference API
    :toctree: generated/
 
    abagen.get_expression_data
+   abagen.get_samples_in_mask
 
 .. _ref_datasets:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,3 +26,4 @@ abagen/issues>`_.
    user_guide/probes.rst
    user_guide/normalization.rst
    user_guide/aggregation.rst
+   user_guide/mask.rst

--- a/docs/user_guide/mask.rst
+++ b/docs/user_guide/mask.rst
@@ -1,0 +1,81 @@
+.. _usage_mask:
+
+Using a binary mask
+===================
+
+.. _usage_mask_basic:
+
+Basic usage
+-----------
+
+Sometimes, you're not interested in aggregating microarray expression samples
+within regions of an atlas—you want the actual, sample-level data instead. In
+this case, we provides the :func:`abagen.get_samples_in_mask` function.
+
+To demonstrate how this works, we'll first make a brainmask for the left
+parahippocampal gyrus using the region definition from the Desikan-Killiany
+atlas:
+
+.. doctest::
+
+    >>> import nibabel as nib
+    >>> atlas = abagen.fetch_desikan_killiany()
+    >>> dk = nib.load(atlas['image'])
+    >>> phg = dk.__class__(dk.dataobj[:] == 67, dk.affine, dk.header)
+
+We can then use this mask to obtain all the microarray samples that fall within
+its boundaries:
+
+.. doctest::
+
+    >>> exp, coords = abagen.get_samples_in_mask(mask=phg)
+
+:func:`abagen.get_samples_in_mask` returns two objects: (1) the the samples x
+gene expression matrix (``exp``), and (2) an array of MNI coordinates for those
+samples (``coords``). Because this is using :func:`abagen.get_expression_data`
+under the hood, the returned expression data have been preprocessed (i.e.,
+filtered, normalized) according to that workflow. As such, you can provide all
+the same parameters and keyword arguments to :func:`abagen.get_samples_in_mask`
+as you can to :func:`abagen.get_expression_data` (with the exception of
+``atlas`` which is superseded by ``mask`` and ``region_agg``/``agg_metric``
+which will be ignored). Refer to the :ref:`API documentation <api_ref>`) for
+more details!
+
+Since the returned expression dataframe is a samples x gene matrix (rather than
+regions x gene), the index of the dataframe corresponds to the unique well ID
+of the relevant sample (rather than the atlas region):
+
+.. doctest::
+
+    >>> exp.head()
+    gene_symbol      A1BG  A1BG-AS1       A2M  ...       ZYX     ZZEF1      ZZZ3
+    well_id                                    ...
+    2850         0.679381  0.069934  0.398107  ...  0.000000  0.000000  0.000000
+    998          0.354435  0.441267  0.752046  ...  0.487668  0.091851  0.681403
+    990          0.318782  0.531280  0.958299  ...  0.536189  0.187061  0.695825
+    ...               ...       ...       ...  ...       ...       ...       ...
+    141667159    1.000000  1.000000  0.476643  ...  0.840348  0.175459  0.445667
+    159226157    1.000000  0.000000  1.000000  ...  0.000000  0.000000  0.000000
+    159226117    0.000000  1.000000  0.000000  ...  1.000000  1.000000  1.000000
+    <BLANKLINE>
+    [40 rows x 15633 columns]
+
+This allows you to match up the samples with additional data provided by
+the AHBA (e.g., ontological information) as desired.
+
+.. _usage_mask_all:
+
+Get ALL the samples
+-------------------
+
+If you want all of the available processed samples rather than only those
+within a given mask you can call the function without providing an explicit
+mask:
+
+.. doctest::
+    :options: +SKIP
+
+    >>> exp, coords = abagen.get_samples_in_mask(mask=None)
+
+This will return all samples (after dropping those where the listed MNI
+coordinates don't match the listed hemisphere designation, etc.).

--- a/docs/user_guide/mask.rst
+++ b/docs/user_guide/mask.rst
@@ -28,7 +28,7 @@ its boundaries:
 
 .. doctest::
 
-    >>> exp, coords = abagen.get_samples_in_mask(mask=phg)
+    >>> expression, coords = abagen.get_samples_in_mask(mask=phg)
 
 :func:`abagen.get_samples_in_mask` returns two objects: (1) the the samples x
 gene expression matrix (``exp``), and (2) an array of MNI coordinates for those
@@ -47,16 +47,16 @@ of the relevant sample (rather than the atlas region):
 
 .. doctest::
 
-    >>> exp.head()
+    >>> expression
     gene_symbol      A1BG  A1BG-AS1       A2M  ...       ZYX     ZZEF1      ZZZ3
     well_id                                    ...
-    2850         0.679381  0.069934  0.398107  ...  0.000000  0.000000  0.000000
-    998          0.354435  0.441267  0.752046  ...  0.487668  0.091851  0.681403
-    990          0.318782  0.531280  0.958299  ...  0.536189  0.187061  0.695825
+    2850         0.654914  0.234039  0.283280  ...  0.020379  0.228080  0.000000
+    998          0.428705  0.375819  0.457741  ...  0.254195  0.315383  0.502122
+    990          0.400673  0.409852  0.561666  ...  0.270064  0.397740  0.522261
     ...               ...       ...       ...  ...       ...       ...       ...
-    141667159    1.000000  1.000000  0.476643  ...  0.840348  0.175459  0.445667
-    159226157    1.000000  0.000000  1.000000  ...  0.000000  0.000000  0.000000
-    159226117    0.000000  1.000000  0.000000  ...  1.000000  1.000000  1.000000
+    141667159    0.829192  0.923891  0.408131  ...  0.347914  0.302548  0.615491
+    159226157    0.558571  0.710222  0.372123  ...  0.360930  0.337352  0.453750
+    159226117    0.533079  0.773214  0.265615  ...  0.441826  0.389615  0.455249
     <BLANKLINE>
     [40 rows x 15633 columns]
 
@@ -70,12 +70,12 @@ Get ALL the samples
 
 If you want all of the available processed samples rather than only those
 within a given mask you can call the function without providing an explicit
-mask:
+mask (this is the default when no ``mask`` parameter is passed):
 
 .. doctest::
     :options: +SKIP
 
-    >>> exp, coords = abagen.get_samples_in_mask(mask=None)
+    >>> expression, coords = abagen.get_samples_in_mask(mask=None)
 
 This will return all samples (after dropping those where the listed MNI
 coordinates don't match the listed hemisphere designation, etc.).

--- a/docs/user_guide/normalization.rst
+++ b/docs/user_guide/normalization.rst
@@ -248,3 +248,28 @@ with caution!
   **Applicable methods**: :ref:`robust sigmoid <usage_norm_rs>`,
   :ref:`scaled robust sigmoid <usage_norm_srs>`,
   :ref:`mixed sigmoid <usage_norm_mixedsig>`
+
+Normalizing only matched samples
+--------------------------------
+
+While sample normalization is _always_ performed across all genes, you can
+control which samples are used when performing gene normalization. By default,
+only those samples matched to regions in the provided atlas are used in the
+normalization process (via the ``norm_matched`` parameter):
+
+.. code-block:: python
+
+    >>> abagen.get_expression_data(atlas['image'], norm_matched=True)
+
+Since there are known differences in microarray expression between broad
+structural designations (e.g. cortex, subcortex, brainstem, cerebellum), if
+e.g., a cortical atlas is provided then it makes sense that only those samples
+matched to regions in the atlas should be used to perform normalization.
+However, when a smaller atlas is provided with only a few regions, normalizing
+over just those samples matched to the atlas can be less desirable. To make it
+so that all available samples are used instead of only those matched, set
+``norm_matched`` to ``False``:
+
+.. code-block:: python
+
+    >>> abagen.get_expression_data(atlas['image'], norm_matched=False)


### PR DESCRIPTION
Closes #46.

Adds function `abagen.get_samples_in_mask(mask)` which allows users to provide a mask (binary or otherwise 🤷‍♂️) and all samples within `tolerance` of mask boundaries are returned (along with MNI coordinates of samples). If no mask is provided, (i.e., `mask=None`) all available tissue samples are returned instead.

This required adding a `region_agg=None` option to `abagen.get_expression_data()`, though I am choosing not to document this functionality in favor of having people use `get_samples_in_mask()` directly so that the relevant sample coordinates are returned alongside expression data.

To do:
- [x] Add smoke tests for `get_samples_in_mask()`
- [x] Update documentation for function