### PR TITLE
[FIX] Read_csv error when using pandas > 1.2.0

### DIFF
--- a/abagen/io.py
+++ b/abagen/io.py
@@ -95,7 +95,7 @@ def read_microarray(fname, copy=False, parquet=True):
             data = pd.read_csv(fname, header=None, index_col=0)
         data.index.name = 'probe_id'
         data.columns = pd.Series(range(len(data.columns)), name='sample_id')
-    except (AttributeError, ValueError):
+    except (AttributeError, ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to Microarray'
                             'Expression.csv file from Allen Human Brain '
@@ -136,7 +136,7 @@ def read_ontology(fname, copy=False):
 
     try:
         data = pd.read_csv(fname)
-    except ValueError:
+    except (ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to Ontology.csv '
                             'file from Allen Human Brain Atlas.')
@@ -195,7 +195,7 @@ def read_pacall(fname, copy=False, parquet=True):
             data = pd.read_csv(fname, header=None, index_col=0)
         data.index.name = 'probe_id'
         data.columns = pd.Series(range(len(data.columns)), name='sample_id')
-    except (AttributeError, ValueError):
+    except (AttributeError, ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to PACall.csv '
                             'file from Allen Human Brain Atlas.')
@@ -234,7 +234,7 @@ def read_probes(fname, copy=False):
 
     try:
         data = pd.read_csv(fname, index_col=0)
-    except ValueError:
+    except (ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to Probes.csv '
                             'file from Allen Human Brain Atlas.')
@@ -295,7 +295,7 @@ def read_annotation(fname, copy=False):
     try:
         data = pd.read_csv(fname)
         data.index.name = 'sample_id'
-    except ValueError:
+    except (ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to Annotation'
                             '.csv file from Allen Human Brain Atlas.')
@@ -337,7 +337,7 @@ def read_tpm(fname, copy=False):
         data = pd.read_csv(fname, header=None, index_col=0)
         data.index.name = 'gene_symbol'
         data.columns = pd.Series(range(len(data.columns)), name='sample_id')
-    except ValueError:
+    except (ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to RNAseqTPM'
                             '.csv file from Allen Human Brain Atlas.')
@@ -378,7 +378,7 @@ def read_counts(fname, copy=False):
         data = pd.read_csv(fname, header=None, index_col=0)
         data.index.name = 'gene_symbol'
         data.columns = pd.Series(range(len(data.columns)), name='sample_id')
-    except ValueError:
+    except (ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to RNAseqCounts'
                             '.csv file from Allen Human Brain Atlas.')
@@ -416,7 +416,7 @@ def read_genes(fname, copy=False):
 
     try:
         data = pd.read_csv(fname, index_col=0)
-    except ValueError:
+    except (ValueError, TypeError):
         if not isinstance(fname, pd.DataFrame):
             raise TypeError('Provided fname must be filepath to Annotation'
                             '.csv file from Allen Human Brain Atlas.')

--- a/abagen/tests/test_samples.py
+++ b/abagen/tests/test_samples.py
@@ -131,7 +131,7 @@ def test_drop_mismatch_samples(mm_annotation, ontology):
                                  structure_name=['subiculum, left',
                                                  'claustrum, right',
                                                  'central canal']),
-                            index=[0, 2, 4])
+                            index=pd.Series([0, 2, 4], name='sample_id'))
 
     # do we get what we expect? (ignore ordering of columns / index)
     out = samples_.drop_mismatch_samples(mm_annotation, ontology)
@@ -164,7 +164,7 @@ def test_mirror_samples(annotation, ontology):
                                              'central canal',
                                              'subiculum, right',
                                              'claustrum, left']),
-                        index=[0, 1, 2, 0, 1])
+                        index=pd.Series([0, 1, 2, 0, 1], name='sample_id'))
 
     # but let's confirm all the outputs are as-expected
     a = samples_.mirror_samples(annotation, ontology)

--- a/abagen/utils.py
+++ b/abagen/utils.py
@@ -209,10 +209,11 @@ def check_atlas_info(atlas, atlas_info, labels=None, validate=False):
     expected_cols = ['hemisphere', 'structure']
 
     # load info, if not already
-    try:
-        atlas_info = pd.read_csv(atlas_info)
-    except ValueError:
-        pass
+    if not isinstance(atlas_info, pd.DataFrame):
+        try:
+            atlas_info = pd.read_csv(atlas_info)
+        except (ValueError, TypeError):
+            pass
 
     try:
         atlas_info = atlas_info.copy()


### PR DESCRIPTION
Addresses #166 

As of pandas 1.2.0 when `pd.read_csv` is given a DataFrame object it throws a `TypeError` (instead of a `ValueError`). This PR adjusts all previously handled exceptions to deal with the new error type and fixes other errors stemming from new version issues.