### PR TITLE
[ENH] Add `norm_structures` parameter

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -32,6 +32,7 @@ def get_expression_data(atlas,
                         sample_norm='srs',
                         gene_norm='srs',
                         norm_matched=True,
+                        norm_structures=False,
                         region_agg='donors',
                         agg_metric='mean',
                         corrected_mni=True,
@@ -152,6 +153,10 @@ def get_expression_data(atlas,
         samples matched to regions in `atlas` instead of all available samples.
         If `atlas` is very small (i.e., only a few regions of interest), using
         `norm_matched=False` is suggested. Default: True
+    norm_structures : bool, optional
+        Whether to perform gene normalization (`gene_norm`) within structural
+        classes (i.e., 'cortex', 'subcortex/brainstem', 'cerebellum') instead
+        of across all available samples. Default: False
     region_agg : {'samples', 'donors'}, optional
         When multiple samples are identified as belonging to a region in
         `atlas` this determines how they are aggegated. If 'samples',
@@ -404,6 +409,8 @@ def get_expression_data(atlas,
             annotation[subj] = annotation[subj].loc[nz]
             labels = labels.loc[nz]
 
+        # if normalizing by structural class get annotation dataframe
+        annot = annotation[subj][['structure']] if norm_structures else None
         if sample_norm is not None:
             microarray[subj] = correct.normalize_expression(microarray[subj].T,
                                                             norm=sample_norm,
@@ -411,6 +418,7 @@ def get_expression_data(atlas,
         if gene_norm is not None:
             microarray[subj] = correct.normalize_expression(microarray[subj],
                                                             norm=gene_norm,
+                                                            structures=annot,
                                                             ignore_warn=True)
 
         # get counts of samples collapsed into each ROI

--- a/abagen/tests/test_correct.py
+++ b/abagen/tests/test_correct.py
@@ -170,6 +170,25 @@ def test_normalize_expression_real(testfiles, method):
     #     correct.normalize_expression(micro[0], norm='batch')
 
 
+def text_normalize_expression_structures():
+    data = pd.DataFrame(dict(a=[np.nan, 1, 2, 3, 4], b=[np.nan, 1, 2, 3, 4]))
+
+    same = pd.DataFrame(dict(structure='a'), index=data.index)
+    same_expect = pd.DataFrame(dict(
+        a=[np.nan, -1.5, -0.5, 0.5, 1.5], b=[np.nan, -1.5, -0.5, 0.5, 1.5]
+    ))
+    nsame = correct.normalize_expression(data, norm='center', structures=same)
+    pd.testing.assert_frame_equal(same_expect, nsame)
+
+    diff = pd.DataFrame(dict(structure=['a', 'a', 'a', 'b', 'b']),
+                        index=data.index)
+    diff_expect = pd.DataFrame(dict(
+        a=[np.nan, -0.5, 0.5, -0.5, 0.5], b=[np.nan, -0.5, 0.5, -0.5, 0.5]
+    ))
+    ndiff = correct.normalize_expression(data, norm='center', structures=diff)
+    pd.testing.assert_frame_equal(diff_expect, ndiff)
+
+
 def test_remove_distance(donor_expression, atlas):
     expr = pd.concat(donor_expression).groupby('label').aggregate(np.mean)
     expr = expr.dropna(axis=1, how='any')

--- a/docs/user_guide/normalization.rst
+++ b/docs/user_guide/normalization.rst
@@ -263,10 +263,6 @@ normalization process (controllable via the ``norm_matched`` parameter):
 
     >>> abagen.get_expression_data(atlas['image'], norm_matched=True)
 
-Since there are known differences in microarray expression between broad
-structural designations (e.g. cortex, subcortex, brainstem, cerebellum), if
-e.g., a cortical atlas is provided then it makes sense that only those samples
-matched to regions in the atlas should be used to perform normalization.
 However, when a smaller atlas is provided with only a few regions, normalizing
 over just those samples matched to the atlas can be less desirable. To make it
 so that all available samples are used instead of only those matched, set
@@ -292,3 +288,24 @@ so that all available samples are used instead of only those matched, set
     in missing regions. For this reason, we suggest using
     ``norm_matched=False`` when also using ``exact=False``; however, we do not
     impose a restriction on this.
+
+.. _usage_norm_structures:
+
+Normalizing within structural classes
+-------------------------------------
+
+There are known differences in microarray expression between broad structural
+designations (e.g. cortex, subcortex/brainstem, cerebellum). As such, it may
+occasionally be desirable to constrain normalization such that the procedure is
+performed separately for each structural designation. This process can be
+controlled via the ``norm_structures`` parameter:
+
+.. code-block:: python
+
+    >>> abagen.get_expression_data(atlas['image'], norm_structures=True)
+
+By default, this parameter is set to ``False`` and normalization uses all
+available samples. Note that changing this parameter will _dramatically_ modify
+the returned expression information, so use with caution. For obvious reasons
+this parameter will interact heavily with the ``norm_matched`` parameter
+described above.


### PR DESCRIPTION
Adds `norm_structures` parameter to `abagen.get_expression_data()`, which controls whether gene normalization occurs globally (across all samples) or independently for different structural classes (i.e., cortex, subcortex/brainstem, cerebellum).