### PR TITLE
[REF] Constrains centroid matching by atlas_info

### DIFF
--- a/abagen/tests/test_correct.py
+++ b/abagen/tests/test_correct.py
@@ -16,8 +16,8 @@ from abagen.utils import flatten_dict
 
 @pytest.fixture(scope='module')
 def donor_expression(testfiles, atlas):
-    return allen.get_expression_data(atlas['image'], atlas['info'],
-                                     exact=False, return_donors=True,
+    return allen.get_expression_data(atlas['image'], exact=False,
+                                     return_donors=True,
                                      donors=['12876', '15496'])
 
 

--- a/abagen/tests/test_matching.py
+++ b/abagen/tests/test_matching.py
@@ -96,6 +96,20 @@ def test_AtlasTree(atlas, surface, testfiles):
     labels = tree.label_samples(np.row_stack((coords, [1000, 1000, 1000])))
     assert np.all(labels['label'] == [2, 2, 2, 1, 1, 1, 0])
 
+    # check centroid matching
+    lab, dist = tree.match_closest_centroids([[-1, -1, -1]], return_dist=True)
+    assert np.all(lab == 2)
+    assert np.allclose(dist, np.sqrt(3))
+    centinfo = pd.DataFrame(dict(mni_x=[-1], mni_y=[-1], mni_z=[-1],
+                                 hemisphere='L', structure='cortex'))
+    lab, dist = tree.match_closest_centroids([[-1, -1, -1]], return_dist=True)
+    assert np.all(lab == 2)
+    assert np.allclose(dist, np.sqrt(3))
+    centinfo['structure'] = 'cerebellum'
+    lab, dist = tree.match_closest_centroids(centinfo, return_dist=True)
+    assert np.all(lab == -1)
+    assert np.all(np.isinf(dist))
+
     # check providing niimg-like atlas
     tree = matching.AtlasTree(nib.load(atlas['image']))
     assert str(tree) == 'AtlasTree[n_rois=83, n_voxel=819621]'


### PR DESCRIPTION
Closes #6.

This PR updates how "inexact" matching is performed in the `abagen.get_expression_data()` workflow (i.e., when `exact=False`). This matching is now constrained by hemisphere + structural class designation, as designated in `atlas_info`; if `atlas_info` is not provided then the centroid matching is performed as before.