### PR TITLE
[FIX] Bug when `tolerance=0`

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -428,6 +428,13 @@ def get_expression_data(atlas,
         # regions, remove the non-labelled samples prior to normalization.
         # otherwise, we'll remove the non-labelled samples after normalization
         nz = np.asarray(labels != 0).squeeze()
+        if nz.sum() == 0:
+            warnings.warn(f'No samples matched to atlas for donor {subj}',
+                          stacklevel=2)
+            microarray[subj].index = labels['label']
+            if not exact:
+                missing += [(pd.DataFrame(), {})]
+            continue
         if norm_matched:
             microarray[subj] = microarray[subj].loc[nz]
             annotation[subj] = annotation[subj].loc[nz]

--- a/abagen/matching.py
+++ b/abagen/matching.py
@@ -257,8 +257,8 @@ class AtlasTree:
         """
 
         cols = ['mni_x', 'mni_y', 'mni_z']
-        tol = 0
-        labels = np.zeros(len(samples))
+        samples[cols] = np.floor(samples[cols])
+        tol, labels = 0, np.zeros(len(samples))
         idx = np.ones(len(samples), dtype=bool)
         while tol <= tolerance and np.sum(idx) > 0:
             subsamp = samples.loc[idx]


### PR DESCRIPTION
Fixes an error raised when `tolerance=0` where no samples were matched to the provided volumetric atlas. (This was due to changes in #169 that led to using MNI coordinates even for volumetric atlases, such that NO samples are exactly within the volumetric grid. We take the floor of the MNI coordinates now to avoid this error.)

Also, `abagen.get_expression_data()` now issues a warning (and avoids errors) if any donors have _no samples_ matched to an atlas.