### PR TITLE
[FIX] Nan hemisphere designation

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -469,7 +469,7 @@ def get_expression_data(atlas,
             annotree = matching.AtlasTree(
                 np.asarray(annotation_iloc),
                 np.asarray(annotation[subj][cols]),
-                annotation[subj].set_axis(annotation_iloc)
+                annotation[subj].set_axis(annotation_iloc, inplace=False)
             )
             centroids = np.r_[[atlas[subj].centroids[lab] for lab in empty]]
             if atlas[subj].atlas_info is not None:

--- a/abagen/samples_.py
+++ b/abagen/samples_.py
@@ -210,7 +210,8 @@ def drop_mismatch_samples(annotation, ontology):
     sid = np.asarray(annotation['structure_id'])
 
     # get hemisphere and structure path
-    hemisphere = np.asarray(ontology.loc[sid, 'hemisphere'])
+    hemisphere = np.asarray(ontology.loc[sid, 'hemisphere']
+                                    .replace({np.nan: 'B'}))
     structure = np.asarray(ontology.loc[sid, 'structure_id_path']
                                    .apply(_get_struct))
 

--- a/abagen/samples_.py
+++ b/abagen/samples_.py
@@ -220,7 +220,7 @@ def drop_mismatch_samples(annotation, ontology):
     annot = annotation.assign(hemisphere=hemisphere, structure=structure) \
                       .query('(hemisphere == "L" & mni_x < 0) '
                              '| (hemisphere == "R" & mni_x > 0) '
-                             '| (hemisphere.isna() & mni_x == 0)',
+                             '| (hemisphere == "B" & mni_x == 0)',
                              engine='python')
 
     return annot

--- a/abagen/tests/test_samples.py
+++ b/abagen/tests/test_samples.py
@@ -123,7 +123,7 @@ def test__get_struct(path, expected):
 def test_drop_mismatch_samples(mm_annotation, ontology):
     # here's what we expect (i.e., indices 1 & 3 are dropped and the structure
     # for the remaining samples is correctly extracted from the paths)
-    expected = pd.DataFrame(dict(hemisphere=['L', 'R', np.nan],
+    expected = pd.DataFrame(dict(hemisphere=['L', 'R', 'B'],
                                  mni_x=[-10, 30, 0],
                                  structure_acronym=['S', 'Cl', 'CC'],
                                  structure=['subcortex/brainstem',


### PR DESCRIPTION
Fixes an issue where certain structures are bilateral (but the ontology has the hemisphere listed as "NaN"). Also suppresses a warning for `pd.DataFrame.set_axis()` by explicitly passing the `inplace` parameter.