### PR TITLE
[REF] Allow negative tolerance for surfaces

### DIFF
--- a/abagen/matching.py
+++ b/abagen/matching.py
@@ -247,10 +247,15 @@ class AtlasTree:
         if self.atlas_info is not None:
             labels = _check_label(labels, samples, self.atlas_info)
 
-        if len(labels) > 1:
-            with np.errstate(invalid='ignore'):
-                mask = dist > dist.mean() + (dist.std(ddof=1) * tolerance)
-            labels[mask] = 0
+        if tolerance < 0:
+            mask = dist > -tolerance
+        else:
+            if len(labels) > 1:
+                with np.errstate(invalid='ignore'):
+                    mask = dist > dist.mean() + (dist.std(ddof=1) * tolerance)
+            else:
+                mask = np.zeros(len(labels), dtype=bool)
+        labels[mask] = 0
 
         return labels
 

--- a/abagen/matching.py
+++ b/abagen/matching.py
@@ -207,7 +207,7 @@ class AtlasTree:
                 samples['structure'] = 'cortex'
 
         if self.volumetric:
-            labels = self._match_volume(samples, tolerance)
+            labels = self._match_volume(samples, abs(tolerance))
         else:
             cortex = samples['structure'] == 'cortex'
             labels = np.zeros(len(samples))

--- a/abagen/reporting.py
+++ b/abagen/reporting.py
@@ -293,6 +293,14 @@ class Report:
             parcel.
             """.format(space='MNI' if self.group_atlas else 'native voxel',
                        tolerance=self.tolerance)
+        elif self.tolerance < 0 and not self.atlas.volumetric:
+            report += """
+            Samples were assigned to brain regions by minimizing the Euclidean
+            distance between the {space} coordinates of each sample and the
+            nearest surface vertex. Samples where the Euclidean distance to the
+            nearest vertex was more than {tolerance}mm were excluded.
+            """.format(space='MNI' if self.group_atlas else 'native voxel',
+                       tolerance=abs(self.tolerance))
 
         if self.atlas_info is not None:
             report += """

--- a/abagen/tests/test_matching.py
+++ b/abagen/tests/test_matching.py
@@ -147,6 +147,12 @@ def test_AtlasTree(atlas, surface, testfiles):
     labels = tree.label_samples([tree.centroids[1], tree.centroids[2]])
     assert np.all(labels['label'] == [1, 2])
 
+    # check negative surface tolerance
+    labels = tree.label_samples([-72, -25, -13], tolerance=-4)
+    assert np.all(labels['label'] == 14)
+    labels = tree.label_samples([-72, -25, -13], tolerance=-3)
+    assert np.all(labels['label'] == 0)
+
     # no coordinates
     with pytest.raises(ValueError):
         matching.AtlasTree(np.random.choice(10, size=(100,)))


### PR DESCRIPTION
Wherein negative tolerance will ensure samples are not matched to vertices that are more than `-tolerance` mm away (rather than `tolerance` operating as a standard deviation threshold).