### PR TITLE
[FIX] Fixes 'average' probe selection bug

### DIFF
--- a/abagen/probes_.py
+++ b/abagen/probes_.py
@@ -437,7 +437,8 @@ def _average(expression, probes, *args, **kwargs):
     """
 
     def _avg(df):
-        return df.join(probes['gene_symbol'], on='probe_id') \
+        return df.rename(probes['gene_symbol'].to_dict()) \
+                 .rename_axis('gene_symbol') \
                  .groupby('gene_symbol') \
                  .mean().T
 

--- a/abagen/tests/test_probes.py
+++ b/abagen/tests/test_probes.py
@@ -244,6 +244,8 @@ def test_collapse_probes(testfiles, method):
     assert len(out) == 2  # number of donors
     assert np.all([len(exp) == n_samp for exp, n_samp in zip(out, [363, 470])])
     assert np.all([len(exp.columns) == 29131 for exp in out])
+    assert out[0].index.name == 'sample_id'
+    assert out[0].columns.name == 'gene_symbol'
 
 
 @pytest.mark.parametrize('donor_probes', [


### PR DESCRIPTION
The index of the expression dataframes were being lost when `probe_selection='average'` was used due to a `.join()` function, causing everything downstream to break. This fixes that issue and adds a test to check for it in the future.