### PR TITLE
[ENH] Add geometry/space option to check_atlas

### DIFF
--- a/abagen/datasets/fetchers.py
+++ b/abagen/datasets/fetchers.py
@@ -465,15 +465,21 @@ Brain = namedtuple('Brain', ('lh', 'rh'))
 Surface = namedtuple('Surface', ('vertices', 'faces'))
 
 
-def fetch_fsaverage5():
+def fetch_fsaverage5(load=True):
     """
-    Fetches and load fsaverage5 surface
+    Fetches and optionally loads fsaverage5 surface
+
+    Parameters
+    ----------
+    load : bool, optional
+        Whether to pre-load files. Default: True
 
     Returns
     -------
     brain : namedtuple ('lh', 'rh')
-        Where each entry in the tuple is a hemisphere, represented as a
-        namedtuple with fields ('vertices', 'faces')
+        If `load` is True, a namedtuple where each entry in the tuple is a
+        hemisphere, represented as a namedtuple with fields ('vertices',
+        'faces'). If `load` is False, a namedtuple where entries are filepaths.
     """
 
     hemispheres = []
@@ -481,14 +487,18 @@ def fetch_fsaverage5():
         fn = RESOURCE(
             os.path.join('data', f'fsaverage5-pial-{hemi}.surf.gii.gz')
         )
-        hemispheres.append(Surface(*load_gifti(fn).agg_data()))
+        if load:
+            hemispheres.append(Surface(*load_gifti(fn).agg_data()))
+        else:
+            hemispheres.append(fn)
 
     return Brain(*hemispheres)
 
 
-def fetch_fsnative(donors, surf='pial', data_dir=None, resume=True, verbose=1):
+def fetch_fsnative(donors, surf='pial', load=True, data_dir=None, resume=True,
+                   verbose=1):
     """
-    Fetches and load fsnative surface of `donor`
+    Fetches and optionally loads fsnative surface of `donor`
 
     Parameters
     ----------
@@ -497,6 +507,8 @@ def fetch_fsnative(donors, surf='pial', data_dir=None, resume=True, verbose=1):
         specify 'all' to download all available donors.
     surf : {'orig', 'white', 'pial', 'inflated', 'sphere'}, optional
         Which surface to load. Default: 'pial'
+    load : bool, optional
+        Whether to pre-load files. Default: True
     data_dir : str, optional
         Directory where data should be downloaded and unpacked. Default: $HOME/
         abagen-data
@@ -508,9 +520,11 @@ def fetch_fsnative(donors, surf='pial', data_dir=None, resume=True, verbose=1):
     Returns
     -------
     brain : namedtuple ('lh', 'rh')
-        Where each entry in the tuple is a hemisphere, represented as a
-        namedtuple with fields ('vertices', 'faces'). If multiple donors are
-        requested a dictionary is returned where keys are donor IDs.
+        If `load` is True, a namedtuple where each entry in the tuple is a
+        hemisphere, represented as a namedtuple with fields ('vertices',
+        'faces'). If `load` is False, a namedtuple where entries are filepaths.
+        If multiple donors are requested a dictionary is returned where keys
+        are donor IDs.
     """
 
     donors = check_donors(donors)
@@ -524,6 +538,9 @@ def fetch_fsnative(donors, surf='pial', data_dir=None, resume=True, verbose=1):
     hemispheres = []
     for hemi in ('lh', 'rh'):
         fn = os.path.join(fpath, 'surf', f'{hemi}.{surf}')
-        hemispheres.append(Surface(*nib.freesurfer.read_geometry(fn)))
+        if load:
+            hemispheres.append(Surface(*nib.freesurfer.read_geometry(fn)))
+        else:
+            hemispheres.append(fn)
 
     return Brain(*hemispheres)

--- a/abagen/images.py
+++ b/abagen/images.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import warnings
 
 import nibabel as nib
 import numpy as np
@@ -257,7 +256,8 @@ def check_surface(atlas):
                 raise ValueError('Provided GIFTIs do not seem to be valid '
                                  'label.gii files')
         adata.append(data)
-        labs.append(hemi.labeltable.get_labels_as_dict())
+        ldict = hemi.labeltable.get_labels_as_dict()
+        labs.append({k: ldict.get(k) for k in np.unique(data)})
 
     # we need each hemisphere to have unique values so they don't get averaged
     # check to see if the two hemispheres have more than 1 overlapping value
@@ -287,7 +287,7 @@ def check_atlas(atlas, atlas_info=None, geometry=None, space=None, donor=None,
     atlas_info : {os.PathLike, pandas.DataFrame, None}, optional
         Filepath or dataframe containing information about `atlas`. Must have
         at least columns ['id', 'hemisphere', 'structure'] containing
-        information mapping `atlas` IDs to hemisphere (i.e., "L" or "R") and
+        information mapping `atlas` IDs to hemisphere (i.e., "L", "R", "B") and
         broad structural class (i.e.., "cortex", "subcortex/brainstem",
         "cerebellum", "white matter", or "other"). Default: None
     geometry : (2,) tuple-of-GIFTI, optional

--- a/abagen/matching.py
+++ b/abagen/matching.py
@@ -156,7 +156,9 @@ class AtlasTree:
         """ Sets triangles of underlying graph (if applicable)
         """
         if self.volumetric or tris is None:
+            self._triangles = None
             return
+
         atlas = np.zeros(self._shape)
         atlas[self._nz] = self.atlas
         if np.any(tris.max(axis=0) >= self._full_coords.shape[0]):

--- a/abagen/matching.py
+++ b/abagen/matching.py
@@ -159,6 +159,7 @@ class AtlasTree:
             self._triangles = None
             return
 
+        tris = np.asarray(tris)
         atlas = np.zeros(self._shape)
         atlas[self._nz] = self.atlas
         if np.any(tris.max(axis=0) >= self._full_coords.shape[0]):

--- a/abagen/tests/datasets/test_fetchers.py
+++ b/abagen/tests/datasets/test_fetchers.py
@@ -171,6 +171,12 @@ def test_fetch_fsaverage5():
             assert hasattr(hemi, attr)
             assert getattr(hemi, attr).shape == (exp, 3)
 
+    fs5 = fetchers.fetch_fsaverage5(load=False)
+    for hemi in ('lh', 'rh'):
+        assert hasattr(fs5, hemi)
+        hemi = getattr(fs5, hemi)
+        assert Path(hemi).is_file()
+
 
 def test_fetch_fsnative():
     fsn = fetchers.fetch_fsnative(donors=['12876'])
@@ -184,3 +190,9 @@ def test_fetch_fsnative():
         hemi = getattr(fsn, hemi)
         for attr in ('vertices', 'faces'):
             assert hasattr(hemi, attr)
+
+    fsn = fetchers.fetch_fsnative(donors=['12876'], load=False)
+    for hemi in ('lh', 'rh'):
+        assert hasattr(fsn, hemi)
+        hemi = getattr(fsn, hemi)
+        assert Path(hemi).is_file()

--- a/abagen/tests/test_matching.py
+++ b/abagen/tests/test_matching.py
@@ -142,10 +142,15 @@ def test_AtlasTree(atlas, surface, testfiles):
     tree = images.check_atlas(surface['image'])
     assert str(tree) == 'AtlasTree[n_rois=68, n_vertex=18426]'
     assert not tree.volumetric
+    assert tree.triangles is not None
+    assert tree.graph is not None
     assert isinstance(tree.atlas_info, pd.DataFrame)
     assert len(tree.centroids) == 68
     labels = tree.label_samples([tree.centroids[1], tree.centroids[2]])
     assert np.all(labels['label'] == [1, 2])
+
+    with pytest.raises(ValueError):
+        tree.triangles = [[512423, 512312, 4213215]]
 
     # check negative surface tolerance
     labels = tree.label_samples([-72, -25, -13], tolerance=-4)

--- a/abagen/utils.py
+++ b/abagen/utils.py
@@ -182,7 +182,7 @@ def labeltable_to_df(labels):
                 dict(id=ids, label=label, hemisphere=hemi, structure='cortex')
             ), ignore_index=True
         )
-    info = info.set_index('id').drop([0], axis=0)
+    info = info.set_index('id').drop([0], axis=0).sort_index()
 
     if len(info) != 0:
         return info

--- a/docs/user_guide/parcellations.rst
+++ b/docs/user_guide/parcellations.rst
@@ -180,6 +180,10 @@ by default, be based on the geometry of the FreeSurfer surfaces provided with
 based on different geometry please refer to :ref:`usage_parcellations_special`,
 below.
 
+Finally, when in doubt we recommend simply using a standard-space, group-level
+atlas; however, we are actively investigating whether native-space atlases
+provide any measurable benefits to the ``abagen`` workflows.
+
 .. note::
 
     The donor-native volumetric versions of the DK parcellation shipped with
@@ -211,45 +215,25 @@ internally coerced to `AtlasTree` instances, which is then used to assign
 microarray tissue samples to parcels in the atlas.
 
 Take, for example, a surface atlas in fsaverage6 resolution (by default,
-surface atlases are assumed to be fsaverage5 resolution). In this case, you can
-load the surface atlas and relevant geometry files, create an `AtlasTree`
-object, and use that as your atlas moving forward in the same way you would
-with a pair of GIFTI files:
+surface atlases are assumed to be fsaverage5 resolution). In this case, you
+simply need to supply the relevant geometry files for the atlas and specify
+the space of the atlas:
 
 .. code::
 
-    >>> from abagen import matching, transforms
-    >>> atlas = ('/.../myatlas-fsaverage6-lh.gii', '/.../myatlas-fsaverage6-rh.gii')
-    >>> surf = ('/.../mysurf-fsaverage6-lh.gii', '/.../mysurf-fsaverage6-lh.gii')
-    >>> parcellation, atlas_info = images.check_surface(atlas)
-    >>> coords = np.row_stack([nib.load(fn).agg_data('NIFTI_INTENT_POINTSET') for fn in surf])
-    >>> mni152 = transforms.fsaverage_to_mni152(coords)
-    >>> atlas = matching.AtlasTree(parcellation, coords=mni152, atlas_info=atlas_info)
+    >>> from abagen import images
+    >>> atlas = ('/.../fsaverage6-lh.label.gii', '/.../fsaverage6-rh.label.gii')
+    >>> surf = ('/.../fsaverage6-lh.surf.gii', '/.../fsaverage6-lh.surf.gii')
+    >>> atlas = images.check_atlas(atlas, geometry=surf, space='fsaverage6')
 
-(Note that you need to coerce the fsaverage coordinates---which are in MNI305
-space---to MNI152 space before using them in the :obj:`~.AtlasTree`
-constructor!)
-
-The same procedure can be used for an atlas using fslr32k geometry:
+The same procedure can be used for an atlas using fsLR geometry:
 
 .. code::
 
-    >>> from abagen import matching, transforms
-    >>> atlas = ('/.../myatlas-fslr32k-lh.gii', '/.../myatlas-fslr32k-rh.gii')
-    >>> surf = ('/.../mysurf-fslr32k-lh.gii', '/.../mysurf-fslr32k-lh.gii')
-    >>> parcellation, atlas_info = images.check_surface(atlas)
-    >>> coords = np.row_stack([nib.load(fn).agg_data('NIFTI_INTENT_POINTSET') for fn in surf])
-    >>> atlas = matching.AtlasTree(parcellation, coords=coords, atlas_info=atlas_info)
-
-(Note that because fslr32k is already in MNI space you do not need to transform
-the coordinates before using them in the :obj:`~.matching.AtlasTree`
-constructor.)
-
-.. note::
-
-    When in doubt it is likely best to use a standard-space, group-level atlas;
-    however, we are actively investigating whether native-space atlases provide
-    any measurable benefits to the ``abagen`` workflow.
+    >>> from abagen import images
+    >>> atlas = ('/.../fslr32k-lh.label.gii', '/.../fslr32k-rh.label.gii')
+    >>> surf = ('/.../fslr32k-lh.surf.gii', '/.../fslr32k-lh.surf.gii')
+    >>> atlas = images.check_atlas(atlas, geometry=surf, space='fslr')
 
 .. _MNI space: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1088516/
 .. _fsaverage space: https://surfer.nmr.mgh.harvard.edu/


### PR DESCRIPTION
Makes it much easier to specify non-standard atlases / surfaces, which benefits construction of `AtlasTree` objects and enables better use of graph representation of surfaces