### PR TITLE
[REF] Fix coordinates of get_samples_in_mask

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -660,8 +660,8 @@ def get_samples_in_mask(mask=None, **kwargs):
     kwargs.setdefault('norm_matched', False)
 
     # get expression data + drop sample coordinates that weren't in atlas
-    exp = get_expression_data(**kwargs).reorder_levels(('well_id', 'label'))
-    keep = np.isin(coords.index, exp.index.get_level_values('well_id'))
+    exp = get_expression_data(**kwargs).droplevel('label')
+    keep = np.isin(coords.index, exp.index)
 
     return exp, coords.loc[keep]
 
@@ -710,7 +710,8 @@ def get_interpolated_map(genes, mask, n_neighbors=10, **kwargs):
     # this is a "naive" matching based only on Euclidean distance
     # TODO: use surface distances when working with surfaces
     # TODO: constrain by hemisphere (and structure?)
-    exptree = matching.AtlasTree(np.asarray(expression.index), coords=coords)
+    exptree = matching.AtlasTree(np.asarray(expression.index),
+                                 coords=np.asarray(coords))
     dist, idx = exptree.tree.query(mask.coords, k=n_neighbors)
     dist = _get_weights(dist)
 


### PR DESCRIPTION
Closes #188 

Removes the call to `samples_.drop_mismatch_samples()` in `abagen.get_samples_in_mask()` which was causing coordinates to be out-of-alignment with returned expression data when donor-specific masks were provided. This requires modifying the return `coords` array to be a dataframe (with columns 'x', 'y', and 'z'), but this should not be a major issue.

I've also modified the returned `expression` dataframe to have a multi-index with both `'well_id'` and `'label'` levels (when `region_agg=None` is passed to `abagen.get_expression_data()`). This is useful for many reasons.