### PR TITLE
[FIX] Error with donor-specific atlases and tolerance=0

### DIFF
--- a/abagen/allen.py
+++ b/abagen/allen.py
@@ -422,7 +422,7 @@ def get_expression_data(atlas,
                                          data_dir=data_dir,
                                          verbose=verbose)[donor]['t1w']
         annot = samples_.update_coords(annot, corrected_mni=corrected_mni,
-                                       native_space=t1w, atlas=atlas[donor])
+                                       native_space=t1w)
         if lr_mirror is not None:
             annot = samples_.mirror_samples(annot, ontol, swap=lr_mirror)
         annot = samples_.drop_mismatch_samples(annot, ontol)

--- a/abagen/cli/run.py
+++ b/abagen/cli/run.py
@@ -353,7 +353,6 @@ def main(args=None):
     """
 
     from ..allen import get_expression_data
-    from ..datasets import WELL_KNOWN_IDS as donors
 
     opts = get_parser().parse_args(args)
 
@@ -403,13 +402,8 @@ def main(args=None):
 
     # determine how best to save expression output files
     if opts.save_donors:
-        if opts.donors == 'all':
-            donors = list(donors.value_set('subj'))
-        else:
-            donors = [donors[f] for f in opts.donors]
-
         # save each donor dataframe as a separate file
-        for donor, exp in zip(donors, expression):
+        for donor, exp in expression.items():
             exp_fname = os.path.join(output_path,
                                      fname_pref + '_{}.csv'.format(donor))
             LGR.info('Saving donor {} info to {}'.format(donor, exp_fname))

--- a/abagen/images.py
+++ b/abagen/images.py
@@ -544,4 +544,8 @@ def coerce_atlas_to_dict(atlas, donors, atlas_info=None, data_dir=None):
         LGR.info('Group-level atlas provided; using MNI coords for '
                  'tissue samples')
 
+    # update group atlas status based on what was decided / derived
+    for atl in atlas.values():
+        atl.group_atlas = group_atlas
+
     return atlas, group_atlas

--- a/abagen/samples_.py
+++ b/abagen/samples_.py
@@ -107,8 +107,7 @@ def update_mni_coords(annotation):
     return annotation
 
 
-def update_coords(annotation, corrected_mni=True, native_space=None,
-                  atlas=None):
+def update_coords(annotation, corrected_mni=True, native_space=None):
     """
     Updates coordinates in `annotation`
 
@@ -131,19 +130,10 @@ def update_coords(annotation, corrected_mni=True, native_space=None,
         Annotation data with updated coordinates
     """
 
-    from .images import check_atlas
-
     annotation = io.read_annotation(annotation, copy=True)
 
     if corrected_mni:
         annotation = update_mni_coords(annotation)
-
-    if atlas is not None:
-        atlas = check_atlas(atlas)
-        if atlas.volumetric:
-            cols = ['mni_x', 'mni_y', 'mni_z']
-            vox_size = 1 / atlas._volumetric
-            annotation[cols] = np.floor(annotation[cols] * vox_size) / vox_size
 
     if native_space is not None:
         try:

--- a/abagen/samples_.py
+++ b/abagen/samples_.py
@@ -107,7 +107,8 @@ def update_mni_coords(annotation):
     return annotation
 
 
-def update_coords(annotation, corrected_mni=True, native_space=None):
+def update_coords(annotation, corrected_mni=True, native_space=None,
+                  atlas=None):
     """
     Updates coordinates in `annotation`
 
@@ -130,10 +131,19 @@ def update_coords(annotation, corrected_mni=True, native_space=None):
         Annotation data with updated coordinates
     """
 
+    from .images import check_atlas
+
     annotation = io.read_annotation(annotation, copy=True)
 
     if corrected_mni:
         annotation = update_mni_coords(annotation)
+
+    if atlas is not None:
+        atlas = check_atlas(atlas)
+        if atlas.volumetric:
+            cols = ['mni_x', 'mni_y', 'mni_z']
+            vox_size = 1 / atlas._volumetric
+            annotation[cols] = np.floor(annotation[cols] * vox_size) / vox_size
 
     if native_space is not None:
         try:

--- a/abagen/samples_.py
+++ b/abagen/samples_.py
@@ -475,6 +475,10 @@ def aggregate_samples(microarray, labels=None, region_agg='donors',
     LGR.info('Aggregating samples to regions with provided region_agg: {}'
              .format(region_agg))
 
+    donors = None
+    if isinstance(microarray, dict):
+        donors, microarray = list(microarray.keys()), list(microarray.values())
+
     if region_agg == 'donors':
         microarray = [
             groupby_index(e, labels=labels, metric=metric) for e in microarray
@@ -491,5 +495,8 @@ def aggregate_samples(microarray, labels=None, region_agg='donors',
         LGR.info('Dropping {} gene from concatenated expression data due to '
                  'poor normalization'.format(drop.sum()))
         microarray = microarray.drop(drop[drop].index, axis=1)
+
+    if donors is not None and return_donors:
+        microarray = dict(zip(donors, microarray))
 
     return microarray

--- a/abagen/tests/test_correct.py
+++ b/abagen/tests/test_correct.py
@@ -16,9 +16,9 @@ from abagen.utils import flatten_dict
 
 @pytest.fixture(scope='module')
 def donor_expression(testfiles, atlas):
-    return allen.get_expression_data(atlas['image'], missing='centroids',
-                                     return_donors=True,
-                                     donors=['12876', '15496'])
+    return list(allen.get_expression_data(atlas['image'], missing='centroids',
+                                          return_donors=True,
+                                          donors=['12876', '15496']).values())
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Closes #190.

This modifies the procedure by which sample coordinates are "floored" before matching to regions in the user-provided atlas(es); the flooring procedure is only performed when group atlases are supplied, and rather than flooring we simply round down to the nearest voxel.