### PR TITLE
[REF] Replace DataFrame.append with pd.concat

### DIFF
--- a/abagen/samples_.py
+++ b/abagen/samples_.py
@@ -401,11 +401,9 @@ def groupby_index(microarray, labels=None, metric='mean'):
         labels = pd.DataFrame(columns=microarray.columns,
                               index=pd.Series(missing, name='label'))
 
-    gene_by_label = (microarray.groupby('label')
-                               .aggregate(metric)
-                               .append(labels)
-                               .sort_index()
-                               .rename_axis('label'))
+    gene_by_label = (pd.concat((microarray.groupby('label').aggregate(metric), labels))
+                            .sort_index()
+                            .rename_axis('label'))
 
     # remove "zero" label (if it exists)
     if 0 in gene_by_label.index:


### PR DESCRIPTION
Pandas 1.4.0 creates a FutureWarning warning for the [deprecation](https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append) of `DataFrame.append()`. This PR replaces `.append` with the recommended `pandas.concat`.